### PR TITLE
Add Kino.Frame for animations

### DIFF
--- a/lib/kino.ex
+++ b/lib/kino.ex
@@ -152,4 +152,48 @@ defmodule Kino do
   def configure(options) do
     Kino.Config.configure(options)
   end
+
+  @doc ~S"""
+  Returns a widget that periodically calls the given function
+  to render a new result.
+
+  The callback is run every `interval_ms` milliseconds and receives
+  the accumulated value. The callback should return either of:
+
+    * `{:cont, term_to_render, acc}` - the continue with the new
+      accumulated value
+
+    * `:halt` - to no longer schedule callback evaluation
+
+  This function uses `Kino.Frame` as the underlying widget.
+
+  ## Examples
+
+      # Render new Markdown every 100ms
+      Kino.animate(100, 0, fn i ->
+        md = Kino.Markdown.new("**Iteration: `#{i}`**")
+        {:cont, md, i + 1}
+      end)
+  """
+  @spec animate(
+          pos_integer(),
+          term(),
+          (term() -> {:cont, term(), acc :: term()} | :halt)
+        ) :: Kino.Frame.t()
+  def animate(interval_ms, acc, fun) do
+    widget = Kino.Frame.new()
+
+    Kino.Frame.periodically(widget, interval_ms, acc, fn acc ->
+      case fun.(acc) do
+        {:cont, term, acc} ->
+          Kino.Frame.render(widget, term)
+          {:cont, acc}
+
+        :halt ->
+          :halt
+      end
+    end)
+
+    widget
+  end
 end

--- a/lib/kino.ex
+++ b/lib/kino.ex
@@ -160,8 +160,7 @@ defmodule Kino do
   The callback is run every `interval_ms` milliseconds and receives
   the accumulated value. The callback should return either of:
 
-    * `{:cont, term_to_render, acc}` - the continue with the new
-      accumulated value
+    * `{:cont, term_to_render, acc}` - the continue
 
     * `:halt` - to no longer schedule callback evaluation
 

--- a/lib/kino.ex
+++ b/lib/kino.ex
@@ -178,7 +178,7 @@ defmodule Kino do
           pos_integer(),
           term(),
           (term() -> {:cont, term(), acc :: term()} | :halt)
-        ) :: Kino.Frame.t()
+        ) :: :"do not show this result in output"
   def animate(interval_ms, acc, fun) do
     widget = Kino.Frame.new()
 
@@ -193,6 +193,6 @@ defmodule Kino do
       end
     end)
 
-    widget
+    Kino.render(widget)
   end
 end

--- a/lib/kino/frame.ex
+++ b/lib/kino/frame.ex
@@ -1,0 +1,148 @@
+defmodule Kino.Frame do
+  @moduledoc """
+  A widget wrapping a static output.
+
+  This widget serves as a placeholder for a regular output,
+  so that it can be dynamically replaced at any time.
+
+  Also see `Kino.animate/3` which offers a convenience on
+  top of this widget.
+
+  ## Examples
+
+      widget = Kino.Frame.new() |> tap(&Kino.render/1)
+
+      for i <- 1..100 do
+        Kino.Frame.render(widget, i)
+        Process.sleep(50)
+      end
+
+  Or with a scheduled task in the background.
+
+      widget = Kino.Frame.new() |> tap(&Kino.render/1)
+
+      Kino.Frame.periodically(widget, 50, 0, fn i ->
+        Kino.Frame.render(widget, i)
+        {:cont, i + 1}
+      end)
+  """
+
+  @doc false
+  use GenServer, restart: :temporary
+
+  defstruct [:pid]
+
+  @type t :: %__MODULE__{pid: pid()}
+
+  @typedoc false
+  @type state :: %{
+          parent_monitor_ref: reference(),
+          pids: list(pid()),
+          output: Kino.Output.t() | nil
+        }
+
+  @doc """
+  Starts a widget process.
+  """
+  @spec new() :: t()
+  def new() do
+    parent = self()
+    opts = [parent: parent]
+
+    {:ok, pid} = DynamicSupervisor.start_child(Kino.WidgetSupervisor, {__MODULE__, opts})
+
+    %__MODULE__{pid: pid}
+  end
+
+  @doc false
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @doc """
+  Renders the given term within the frame.
+
+  This works similarly to `Kino.render/1`, but the frame
+  widget only shows the last rendered result.
+  """
+  @spec render(t(), term()) :: :ok
+  def render(widget, term) do
+    GenServer.cast(widget.pid, {:render, term})
+  end
+
+  @doc """
+  Registers a callback to run periodically in the widget process.
+
+  The callback is run every `interval_ms` milliseconds and receives
+  the accumulated value. The callback should return either of:
+
+    * `{:cont, acc}` - the continue with the new accumulated value
+
+    * `:halt` - to no longer schedule callback evaluation
+
+  The callback is run for the first time immediately upon registration.
+  """
+  @spec periodically(t(), pos_integer(), term(), (term() -> {:cont, term()} | :halt)) :: :ok
+  def periodically(widget, interval_ms, acc, fun) do
+    GenServer.cast(widget.pid, {:periodically, interval_ms, acc, fun})
+  end
+
+  @impl true
+  def init(opts) do
+    parent = Keyword.fetch!(opts, :parent)
+
+    parent_monitor_ref = Process.monitor(parent)
+
+    {:ok, %{parent_monitor_ref: parent_monitor_ref, pids: [], output: nil}}
+  end
+
+  @impl true
+  def handle_cast({:render, term}, state) do
+    output = Kino.Render.to_livebook(term)
+
+    for pid <- state.pids do
+      send(pid, {:render, %{output: output}})
+    end
+
+    state = %{state | output: output}
+
+    {:noreply, state}
+  end
+
+  def handle_cast({:periodically, interval_ms, acc, fun}, state) do
+    periodically_iter(interval_ms, acc, fun)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:connect, pid}, state) do
+    Process.monitor(pid)
+
+    send(pid, {:connect_reply, %{output: state.output}})
+
+    {:noreply, %{state | pids: [pid | state.pids]}}
+  end
+
+  def handle_info({:periodically_iter, interval_ms, acc, fun}, state) do
+    periodically_iter(interval_ms, acc, fun)
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, ref, :process, _object, _reason}, %{parent_monitor_ref: ref} = state) do
+    {:stop, :shutdown, state}
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    {:noreply, %{state | pids: List.delete(state.pids, pid)}}
+  end
+
+  defp periodically_iter(interval_ms, acc, fun) do
+    case fun.(acc) do
+      {:cont, acc} ->
+        Process.send_after(self(), {:periodically_iter, interval_ms, acc, fun}, interval_ms)
+
+      :halt ->
+        :ok
+    end
+  end
+end

--- a/lib/kino/output.ex
+++ b/lib/kino/output.ex
@@ -15,6 +15,7 @@ defmodule Kino.Output do
           | vega_lite_static()
           | vega_lite_dynamic()
           | table_dynamic()
+          | frame_dynamic()
 
   @typedoc """
   An empty output that should be ignored whenever encountered.
@@ -126,6 +127,28 @@ defmodule Kino.Output do
   """
   @type table_dynamic :: {:table_dynamic, pid()}
 
+  @typedoc """
+  Animable output.
+
+  There should be a server process responsible for communication
+  with subscribers.
+
+  ## Communication protocol
+
+  A client process should connect to the server process by sending:
+
+      {:connect, pid()}
+
+  And expect the following reply:
+
+      {:connect_reply, %{output: Kino.Output.t() | nil}}
+
+  The server process may then keep sending one of the following events:
+
+      {:render, %{output: Kino.Output.t()}}
+  """
+  @type frame_dynamic :: {:frame_dynamic, pid()}
+
   @doc """
   See `t:text_inline/0`.
   """
@@ -180,6 +203,14 @@ defmodule Kino.Output do
   @spec table_dynamic(pid()) :: t()
   def table_dynamic(pid) when is_pid(pid) do
     {:table_dynamic, pid}
+  end
+
+  @doc """
+  See `t:frame_dynamic/0`.
+  """
+  @spec frame_dynamic(pid()) :: t()
+  def frame_dynamic(pid) when is_pid(pid) do
+    {:frame_dynamic, pid}
   end
 
   @doc """

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -56,6 +56,12 @@ defimpl Kino.Render, for: Kino.Ecto do
   end
 end
 
+defimpl Kino.Render, for: Kino.Frame do
+  def to_livebook(widget) do
+    Kino.Output.frame_dynamic(widget.pid)
+  end
+end
+
 # Elixir built-ins
 
 defimpl Kino.Render, for: Reference do

--- a/lib/kino/vega_lite.ex
+++ b/lib/kino/vega_lite.ex
@@ -120,6 +120,7 @@ defmodule Kino.VegaLite do
   the accumulated value. The callback should return either of:
 
     * `{:cont, acc}` - the continue with the new accumulated value
+
     * `:halt` - to no longer schedule callback evaluation
 
   The callback is run for the first time immediately upon registration.

--- a/test/kino/frame_test.exs
+++ b/test/kino/frame_test.exs
@@ -1,0 +1,62 @@
+defmodule Kino.FrameTest do
+  use ExUnit.Case, async: true
+
+  test "render/2 formats the givne value into output and sends to the client" do
+    widget = Kino.Frame.new()
+
+    connect_self(widget)
+
+    Kino.Frame.render(widget, 1)
+    assert_receive {:render, %{output: {:text, "\e[34m1\e[0m"}}}
+
+    Kino.Frame.render(widget, Kino.Markdown.new("_hey_"))
+    assert_receive {:render, %{output: {:markdown, "_hey_"}}}
+  end
+
+  test "periodically/4 evaluates the given callback in background until stopped" do
+    widget = Kino.Frame.new()
+
+    connect_self(widget)
+
+    Kino.Frame.periodically(widget, 1, 1, fn n ->
+      if n < 3 do
+        Kino.Frame.render(widget, n)
+        {:cont, n + 1}
+      else
+        :halt
+      end
+    end)
+
+    assert_receive {:render, %{output: {:text, "\e[34m1\e[0m"}}}
+    assert_receive {:render, %{output: {:text, "\e[34m2\e[0m"}}}
+    refute_receive {:render, _}, 5
+  end
+
+  test "terminates as soon as the parent process terminates" do
+    root = self()
+
+    parent =
+      spawn_link(fn ->
+        widget = Kino.Frame.new()
+        send(root, {:widget, widget})
+
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    widget =
+      receive do
+        {:widget, widget} -> widget
+      end
+
+    ref = Process.monitor(widget.pid)
+    send(parent, :stop)
+    assert_receive {:DOWN, ^ref, :process, _, _}
+  end
+
+  defp connect_self(widget) do
+    send(widget.pid, {:connect, self()})
+    assert_receive {:connect_reply, %{}}
+  end
+end

--- a/test/kino/vega_lite_test.exs
+++ b/test/kino/vega_lite_test.exs
@@ -104,8 +104,7 @@ defmodule Kino.VegaLiteTest do
 
     assert_receive {:push, %{data: [%{x: 1, y: 1}], dataset: nil, window: nil}}
     assert_receive {:push, %{data: [%{x: 2, y: 2}], dataset: nil, window: nil}}
-    Process.sleep(5)
-    refute_received {:push, _}
+    refute_receive {:push, _}, 5
   end
 
   test "terminates as soon as the parent process terminates" do


### PR DESCRIPTION
Closes #48. For the Livebook counterpart see https://github.com/livebook-dev/livebook/pull/688.

This introduces a new dynamic output that wraps a single static output, which can be replaced at any time. Additionally, we now have `Kino.animate` wrapping the most common use case.

https://user-images.githubusercontent.com/17034772/140779100-c21ebb5e-422e-41cd-acb0-42566bcd6da1.mp4

*Sidenote: `Kino.animate` is how to flip book in Livebook*