### PR TITLE
Return the rendered term from Kino.render/1

### DIFF
--- a/lib/kino.ex
+++ b/lib/kino.ex
@@ -140,10 +140,14 @@ defmodule Kino do
   always produces colored text and respects the configuration
   set with `configure/1`.
   """
-  @spec inscpect(term()) :: term()
-  def inscpect(term) do
-    output = Kino.Output.inspect(term)
+  @spec inscpect(term(), keyword()) :: term()
+  def inscpect(term, opts \\ []) do
+    label = if label = opts[:label], do: "#{label}: ", else: ""
+
+    {:text, text} = Kino.Output.inspect(term, opts)
+    output = {:text, label <> text}
     Kino.Bridge.put_output(output)
+
     term
   end
 

--- a/lib/kino.ex
+++ b/lib/kino.ex
@@ -28,7 +28,7 @@ defmodule Kino do
         |> Vl.data_from_series(...)
         |> ...
         |> Kino.VegaLite.new()
-        |> tap(&Kino.render/1)
+        |> Kino.render()
 
       Kino.VegaLite.push(widget, %{x: 1, y: 2})
 
@@ -95,7 +95,7 @@ defmodule Kino do
   `Kino.Frame` is a placeholder for static outptus that can
   be dynamically updated.
 
-      widget = Kino.Frame.new() |> tap(&Kino.render/1)
+      widget = Kino.Frame.new() |> Kino.render()
 
       for i <- 1..100 do
         Kino.Frame.render(widget, i)
@@ -119,17 +119,17 @@ defmodule Kino do
   @type nothing :: :"do not show this result in output"
 
   @doc """
-  Sends the given term as cell output.
+  Renders the given term as cell output.
 
-  This allows any Livebook cell to have multiple evaluation
-  results. You can think of this function as a generalized
-  `IO.puts/2` that works for any type.
+  This effectively allows any Livebook cell to have multiple
+  evaluation results. You can think of this function as a
+  generalized `IO.inspect/2` that works for any type.
   """
-  @spec render(term()) :: nothing()
+  @spec render(term()) :: term()
   def render(term) do
     output = Kino.Render.to_livebook(term)
     Kino.Bridge.put_output(output)
-    nothing()
+    term
   end
 
   @doc """
@@ -204,6 +204,8 @@ defmodule Kino do
     end)
 
     Kino.render(widget)
+
+    nothing()
   end
 
   @doc """

--- a/lib/kino.ex
+++ b/lib/kino.ex
@@ -139,9 +139,12 @@ defmodule Kino do
   This works essentially the same as `IO.inspect/2`, except it
   always produces colored text and respects the configuration
   set with `configure/1`.
+
+  Opposite to `render/1`, it does not attempt to render the given
+  term as a widget.
   """
-  @spec inscpect(term(), keyword()) :: term()
-  def inscpect(term, opts \\ []) do
+  @spec inspect(term(), keyword()) :: term()
+  def inspect(term, opts \\ []) do
     label = if label = opts[:label], do: "#{label}: ", else: ""
 
     {:text, text} = Kino.Output.inspect(term, opts)

--- a/lib/kino.ex
+++ b/lib/kino.ex
@@ -116,18 +116,33 @@ defmodule Kino do
   `inspect/2`.
   '''
 
+  import Kernel, except: [inspect: 1]
+
   @type nothing :: :"do not show this result in output"
 
   @doc """
   Renders the given term as cell output.
 
   This effectively allows any Livebook cell to have multiple
-  evaluation results. You can think of this function as a
-  generalized `IO.inspect/2` that works for any type.
+  evaluation results.
   """
   @spec render(term()) :: term()
   def render(term) do
     output = Kino.Render.to_livebook(term)
+    Kino.Bridge.put_output(output)
+    term
+  end
+
+  @doc """
+  Inspects the given term as cell output.
+
+  This works essentially the same as `IO.inspect/2`, except it
+  always produces colored text and respects the configuration
+  set with `configure/1`.
+  """
+  @spec inscpect(term()) :: term()
+  def inscpect(term) do
+    output = Kino.Output.inspect(term)
     Kino.Bridge.put_output(output)
     term
   end
@@ -232,7 +247,7 @@ defmodule Kino do
     # would block forever, so we don't allow nesting
     if Kino.DynamicSupervisor in Process.get(:"$ancestors", []) do
       raise ArgumentError,
-            "could not start #{inspect(child_spec)} using Kino.start_child/1," <>
+            "could not start #{Kernel.inspect(child_spec)} using Kino.start_child/1," <>
               " because the current process has been started with Kino.start_child/1." <>
               " Please move the nested start outside and pass the result as an argument to this process"
     end

--- a/lib/kino/frame.ex
+++ b/lib/kino/frame.ex
@@ -10,7 +10,7 @@ defmodule Kino.Frame do
 
   ## Examples
 
-      widget = Kino.Frame.new() |> tap(&Kino.render/1)
+      widget = Kino.Frame.new() |> Kino.render()
 
       for i <- 1..100 do
         Kino.Frame.render(widget, i)
@@ -19,7 +19,7 @@ defmodule Kino.Frame do
 
   Or with a scheduled task in the background.
 
-      widget = Kino.Frame.new() |> tap(&Kino.render/1)
+      widget = Kino.Frame.new() |> Kino.render()
 
       Kino.Frame.periodically(widget, 50, 0, fn i ->
         Kino.Frame.render(widget, i)

--- a/lib/kino/output.ex
+++ b/lib/kino/output.ex
@@ -3,6 +3,8 @@ defmodule Kino.Output do
   A number of output formats supported by Livebook.
   """
 
+  import Kernel, except: [inspect: 2]
+
   @typedoc """
   Livebook cell output may be one of these values and gets rendered accordingly.
   """
@@ -372,16 +374,19 @@ defmodule Kino.Output do
   @doc """
   Returns `t:text_block/0` with the inspected term.
   """
-  @spec inspect(term()) :: t()
-  def inspect(term) do
-    inspected = inspect(term, inspect_opts())
+  @spec inspect(term(), keyword()) :: t()
+  def inspect(term, opts \\ []) do
+    inspected = Kernel.inspect(term, inspect_opts(opts))
     text_block(inspected)
   end
 
-  defp inspect_opts() do
+  defp inspect_opts(opts) do
     default_opts = [pretty: true, width: 100, syntax_colors: syntax_colors()]
     config_opts = Kino.Config.configuration(:inspect, [])
-    Keyword.merge(default_opts, config_opts)
+
+    default_opts
+    |> Keyword.merge(config_opts)
+    |> Keyword.merge(opts)
   end
 
   defp syntax_colors() do

--- a/lib/kino/vega_lite.ex
+++ b/lib/kino/vega_lite.ex
@@ -13,7 +13,7 @@ defmodule Kino.VegaLite do
         |> Vl.encode_field(:x, "x", type: :quantitative)
         |> Vl.encode_field(:y, "y", type: :quantitative)
         |> Kino.VegaLite.new()
-        |> tap(&Kino.render/1)
+        |> Kino.render()
 
       for i <- 1..300 do
         point = %{x: i / 10, y: :math.sin(i / 10)}

--- a/test/kino_test.exs
+++ b/test/kino_test.exs
@@ -1,6 +1,24 @@
 defmodule KinoTest do
   use ExUnit.Case, async: true
 
+  describe "inspect/2" do
+    test "sends a text output to the group leader" do
+      gl =
+        spawn(fn ->
+          assert_receive {:io_request, from, ref, {:livebook_put_output, output}}
+          send(from, {:io_reply, ref, :ok})
+
+          assert {:text, "\e[34m:hey\e[0m"} = output
+        end)
+
+      Process.group_leader(self(), gl)
+
+      Kino.inspect(:hey)
+
+      await_process(gl)
+    end
+  end
+
   describe "start_child/1" do
     test "raises in a process already started as a child" do
       {:ok, pid} =
@@ -13,9 +31,12 @@ defmodule KinoTest do
            end}
         )
 
-      ref = Process.monitor(pid)
-
-      assert_receive {:DOWN, ^ref, :process, _object, _reason}
+      await_process(pid)
     end
+  end
+
+  defp await_process(pid) do
+    ref = Process.monitor(pid)
+    assert_receive {:DOWN, ^ref, :process, _object, _reason}
   end
 end


### PR DESCRIPTION
Closes #59.

@josevalim actually not sure if `Kino.inspect/2` makes sense with this change, because `Kino.render/1` covers most cases and if someone really wants to inspect Kino structs they can always use `IO.inspect` for that?