### PR TITLE
Add Kino.Control.form/2

### DIFF
--- a/lib/kino/control.ex
+++ b/lib/kino/control.ex
@@ -194,10 +194,10 @@ defmodule Kino.Control do
     end
 
     fields =
-      Keyword.map(fields, fn {_field, input} ->
+      Enum.map(fields, fn {field, input} ->
         # Make sure we use this input only in the form and nowhere else
         input = Kino.Input.duplicate(input)
-        input.attrs
+        {field, input.attrs}
       end)
 
     submit = Keyword.get(opts, :submit, nil)

--- a/lib/kino/control.ex
+++ b/lib/kino/control.ex
@@ -119,14 +119,14 @@ defmodule Kino.Control do
   Consequently, the form is another control for producing user-specific
   events.
 
-  Either `:submit` or `:report_change` must be specified.
+  Either `:submit` or `:report_changes` must be specified.
 
   ## Options
 
     * `:submit` - specifies the label to use for the submit button
       and enables submit events
 
-    * `:report_change` - whether to send new form value whenever any
+    * `:report_changes` - whether to send new form value whenever any
       of the input changes. Defaults to `false`
 
     * `:reset_on_submit` - a list of fields to revert to their default
@@ -144,12 +144,16 @@ defmodule Kino.Control do
 
   ## Examples
 
-  Create a form of out inputs:
+  Create a form out of inputs:
 
-      form = Kino.Control.form([
-        name: Kino.Input.text("Name"),
-        message: Kino.Input.textarea("Message")
-      ])
+      form =
+        Kino.Control.form(
+          [
+            name: Kino.Input.text("Name"),
+            message: Kino.Input.textarea("Message")
+          ],
+          submit: "Send"
+        )
 
   Subscribe to events:
 
@@ -189,8 +193,8 @@ defmodule Kino.Control do
       end
     end
 
-    unless opts[:submit] || opts[:report_change] do
-      raise ArgumentError, "expected either :submit or :report_change option to be enabled"
+    unless opts[:submit] || opts[:report_changes] do
+      raise ArgumentError, "expected either :submit or :report_changes option to be enabled"
     end
 
     fields =
@@ -201,7 +205,13 @@ defmodule Kino.Control do
       end)
 
     submit = Keyword.get(opts, :submit, nil)
-    report_change = Keyword.get(opts, :report_change, false)
+
+    report_changes =
+      if Keyword.get(opts, :report_changes, false) do
+        Map.new(fields, fn {field, _} -> {field, true} end)
+      else
+        %{}
+      end
 
     reset_on_submit =
       case Keyword.get(opts, :reset_on_submit, []) do
@@ -214,7 +224,7 @@ defmodule Kino.Control do
       type: :form,
       fields: fields,
       submit: submit,
-      report_change: report_change,
+      report_changes: report_changes,
       reset_on_submit: reset_on_submit
     })
   end

--- a/lib/kino/input.ex
+++ b/lib/kino/input.ex
@@ -39,6 +39,13 @@ defmodule Kino.Input do
     %__MODULE__{attrs: attrs}
   end
 
+  @doc false
+  def duplicate(input) do
+    input.attrs
+    |> Map.drop([:ref, :id, :destination])
+    |> new()
+  end
+
   @doc """
   Creates a new text input.
 

--- a/lib/kino/output.ex
+++ b/lib/kino/output.ex
@@ -296,7 +296,9 @@ defmodule Kino.Output do
               destination: Process.dest(),
               fields: list({field :: atom(), input_attrs()}),
               submit: String.t() | nil,
-              report_change: boolean(),
+              # Currently we always use true, but we can support
+              # other tracking modes in the future
+              report_changes: %{(field :: atom()) => true},
               reset_on_submit: list(field :: atom())
             }
 

--- a/lib/kino/output.ex
+++ b/lib/kino/output.ex
@@ -290,6 +290,15 @@ defmodule Kino.Output do
               destination: Process.dest(),
               label: String.t()
             }
+          | %{
+              type: :form,
+              ref: control_ref(),
+              destination: Process.dest(),
+              fields: list({field :: atom(), input_attrs()}),
+              submit: String.t() | nil,
+              report_change: boolean(),
+              reset_on_submit: list(field :: atom())
+            }
 
   @doc """
   See `t:text_inline/0`.

--- a/test/kino/control_test.exs
+++ b/test/kino/control_test.exs
@@ -17,6 +17,38 @@ defmodule Kino.ControlTest do
     end
   end
 
+  describe "form/1" do
+    test "raises an error for empty field list" do
+      assert_raise ArgumentError, "expected at least one field, got: []", fn ->
+        Kino.Control.form([], submit: "Send")
+      end
+    end
+
+    test "raises an error when value other than input is given" do
+      assert_raise ArgumentError,
+                   "expected each field to be a Kino.Input widget, got: %{id: 1} for :name",
+                   fn ->
+                     Kino.Control.form(name: %{id: 1}, submit: "Send")
+                   end
+    end
+
+    test "raises an error when neither submit nor change trigger is enabled" do
+      assert_raise ArgumentError,
+                   "expected either :submit or :report_change option to be enabled",
+                   fn ->
+                     Kino.Control.form(name: Kino.Input.text("Name"))
+                   end
+    end
+
+    test "supports boolean values to :reset_on_submit" do
+      assert %Kino.Control{attrs: %{reset_on_submit: [:name]}} =
+               Kino.Control.form([name: Kino.Input.text("Name")],
+                 submit: "Send",
+                 reset_on_submit: true
+               )
+    end
+  end
+
   describe "subscribe/2" do
     test "subscribes to control events" do
       button = Kino.Control.button("Name")

--- a/test/kino/control_test.exs
+++ b/test/kino/control_test.exs
@@ -34,18 +34,23 @@ defmodule Kino.ControlTest do
 
     test "raises an error when neither submit nor change trigger is enabled" do
       assert_raise ArgumentError,
-                   "expected either :submit or :report_change option to be enabled",
+                   "expected either :submit or :report_changes option to be enabled",
                    fn ->
                      Kino.Control.form(name: Kino.Input.text("Name"))
                    end
     end
 
-    test "supports boolean values to :reset_on_submit" do
+    test "supports boolean values for :reset_on_submit" do
       assert %Kino.Control{attrs: %{reset_on_submit: [:name]}} =
                Kino.Control.form([name: Kino.Input.text("Name")],
                  submit: "Send",
                  reset_on_submit: true
                )
+    end
+
+    test "supports boolean values for :report_changes" do
+      assert %Kino.Control{attrs: %{report_changes: %{name: true}}} =
+               Kino.Control.form([name: Kino.Input.text("Name")], report_changes: true)
     end
   end
 


### PR DESCRIPTION
Adds support for form control. The form is composed of regular inputs, but inside form those inputs are not synchronized across users. Similarly, refreshing the page discards input values. As with other controls, there is no API for reading the value, instead we can subscribe to events, in this case submit or change. This enables each user to send inputs data a user-specific an event.

https://user-images.githubusercontent.com/17034772/145636268-e681bf03-cec6-4d89-bca8-221b19d86b6d.mp4

*For the Livebook part see https://github.com/livebook-dev/livebook/pull/790.*