### PR TITLE
Add support for exporting JS output

### DIFF
--- a/lib/kino/js.ex
+++ b/lib/kino/js.ex
@@ -382,6 +382,19 @@ defmodule Kino.JS do
     export =
       if info_string = opts[:export_info_string] do
         export_key = opts[:export_key]
+
+        if export_key do
+          unless is_map(data) do
+            raise ArgumentError,
+                  "expected data to be a map, because :export_key is specified, got: #{inspect(data)}"
+          end
+
+          unless is_map_key(data, export_key) do
+            raise ArgumentError,
+                  "got :export_key of #{inspect(export_key)}, but no such key found in data: #{inspect(data)}"
+          end
+        end
+
         %{info_string: info_string, key: export_key}
       end
 

--- a/lib/kino/js.ex
+++ b/lib/kino/js.ex
@@ -148,7 +148,7 @@ defmodule Kino.JS do
   interaction, see `Kino.JS.Live` as a next step in our discussion.
   '''
 
-  defstruct [:module, :data]
+  defstruct [:module, :data, :export]
 
   @type t :: %__MODULE__{module: module(), data: term()}
 
@@ -291,13 +291,11 @@ defmodule Kino.JS do
     {archive_path, hash} = package_assets!(dir, assets)
 
     quote do
-      def __js_info__() do
+      def __assets_info__() do
         %{
-          assets: %{
-            archive_path: unquote(archive_path),
-            js_path: "main.js",
-            hash: unquote(hash)
-          }
+          archive_path: unquote(archive_path),
+          js_path: "main.js",
+          hash: unquote(hash)
         }
       end
 
@@ -352,9 +350,50 @@ defmodule Kino.JS do
 
   The given `data` is passed directly to the JavaScript side during
   initialization.
+
+  ## Options
+
+    * `:export_info_string` - used as the info string for the Markdown
+      code block where output data is persisted
+
+    * `:export_key` - in case the data is a map and only a specific part
+      should be exported
+
+  ## Export
+
+  The output can optionally be exported in notebook source by specifying
+  `:export_info_string`. For example:
+
+      data = "graph TD;A-->B;"
+      Kino.JS.new(__MODULE__, data, export_info_string: "mermaid")
+
+  Would be rendered as the following Live Markdown:
+
+  ````markdown
+  ```mermaid
+  graph TD;A-->B;
+  ```
+  ````
+
+  Non-binary data is automatically serialized to JSON.
   """
-  @spec new(module(), term()) :: t()
-  def new(module, data) do
-    %__MODULE__{module: module, data: data}
+  @spec new(module(), term(), keyword()) :: t()
+  def new(module, data, opts \\ []) do
+    export =
+      if info_string = opts[:export_info_string] do
+        export_key = opts[:export_key]
+        %{info_string: info_string, key: export_key}
+      end
+
+    %__MODULE__{module: module, data: data, export: export}
+  end
+
+  @doc false
+  @spec js_info(t()) :: Kino.Output.js_info()
+  def js_info(%__MODULE__{} = widget) do
+    %{
+      assets: widget.module.__assets_info__(),
+      export: widget.export
+    }
   end
 end

--- a/lib/kino/js/live.ex
+++ b/lib/kino/js/live.ex
@@ -202,7 +202,7 @@ defmodule Kino.JS.Live do
   end
 
   def __before_compile__(env) do
-    unless Module.defines?(env.module, {:__js_info__, 0}) do
+    unless Module.defines?(env.module, {:__assets_info__, 0}) do
       message = """
       make sure to include Kino.JS in #{inspect(env.module)} and define the necessary assets.
 
@@ -227,6 +227,15 @@ defmodule Kino.JS.Live do
   def new(module, init_arg) do
     {:ok, pid} = Kino.start_child({Kino.JS.LiveServer, {module, init_arg}})
     %__MODULE__{module: module, pid: pid}
+  end
+
+  @doc false
+  @spec js_info(t()) :: Kino.Output.js_info()
+  def js_info(%__MODULE__{} = widget) do
+    %{
+      assets: widget.module.__assets_info__(),
+      export: nil
+    }
   end
 
   @doc """

--- a/lib/kino/output.ex
+++ b/lib/kino/output.ex
@@ -98,13 +98,30 @@ defmodule Kino.Output do
 
     * `:js_path` - a relative asset path pointing to the JavaScript
       entrypoint module
+
+  ## Export
+
+  The `:export` map describes how the output should be persisted.
+  The output data is put in a Markdown fenced code block.
+
+    * `:info_string` - used as the info string for the Markdown
+      code block
+
+    * `:key` - in case the data is a map and only a specific part
+      should be exported
   """
   @type js_info() :: %{
           assets: %{
             archive_path: String.t(),
             hash: String.t(),
             js_path: String.t()
-          }
+          },
+          export:
+            nil
+            | %{
+                info_string: String.t(),
+                key: nil | term()
+              }
         }
 
   @typedoc """

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -22,7 +22,7 @@ end
 
 defimpl Kino.Render, for: Kino.JS do
   def to_livebook(widget) do
-    info = widget.module.__js_info__()
+    info = Kino.JS.js_info(widget)
     Kino.Output.js_static(info, widget.data)
   end
 end
@@ -30,7 +30,7 @@ end
 defimpl Kino.Render, for: Kino.JS.Live do
   def to_livebook(widget) do
     Kino.Bridge.reference_object(widget.pid, self())
-    info = widget.module.__js_info__()
+    info = Kino.JS.Live.js_info(widget)
     Kino.Output.js_dynamic(info, widget.pid)
   end
 end

--- a/lib/kino/vega_lite.ex
+++ b/lib/kino/vega_lite.ex
@@ -47,7 +47,7 @@ defmodule Kino.VegaLite do
       datasets: []
     }
 
-    Kino.JS.new(__MODULE__, data)
+    Kino.JS.new(__MODULE__, data, export_info_string: "vega-lite", export_key: :spec)
   end
 
   @doc """

--- a/test/kino/js_test.exs
+++ b/test/kino/js_test.exs
@@ -2,16 +2,16 @@ defmodule Kino.JSTest do
   use ExUnit.Case, async: true
 
   test "packages inline assets" do
-    js_info = Kino.TestModules.JSInlineAssets.__js_info__()
+    assets_info = Kino.TestModules.JSInlineAssets.__assets_info__()
 
-    assert {:ok, files} = :erl_tar.extract(js_info.assets.archive_path, [:memory, :compressed])
+    assert {:ok, files} = :erl_tar.extract(assets_info.archive_path, [:memory, :compressed])
     assert [{'main.css', "body {" <> _}, {'main.js', "export function init(" <> _}] = files
   end
 
   test "packages external assets" do
-    js_info = Kino.TestModules.JSExternalAssets.__js_info__()
+    assets_info = Kino.TestModules.JSExternalAssets.__assets_info__()
 
-    assert {:ok, files} = :erl_tar.extract(js_info.assets.archive_path, [:memory, :compressed])
+    assert {:ok, files} = :erl_tar.extract(assets_info.archive_path, [:memory, :compressed])
     assert [{'main.css', "body {" <> _}, {'main.js', "export function init(" <> _}] = files
   end
 end

--- a/test/kino/js_test.exs
+++ b/test/kino/js_test.exs
@@ -14,4 +14,45 @@ defmodule Kino.JSTest do
     assert {:ok, files} = :erl_tar.extract(assets_info.archive_path, [:memory, :compressed])
     assert [{'main.css', "body {" <> _}, {'main.js', "export function init(" <> _}] = files
   end
+
+  describe "new/3" do
+    test "raises an error when :export_key is specified but data is not a map" do
+      assert_raise ArgumentError,
+                   "expected data to be a map, because :export_key is specified, got: []",
+                   fn ->
+                     Kino.JS.new(Kino.TestModules.JSExternalAssets, [],
+                       export_info_string: "lang",
+                       export_key: :spec
+                     )
+                   end
+    end
+
+    test "raises an error when :export_key not in data" do
+      assert_raise ArgumentError,
+                   "got :export_key of :spec, but no such key found in data: %{width: 10}",
+                   fn ->
+                     Kino.JS.new(Kino.TestModules.JSExternalAssets, %{width: 10},
+                       export_info_string: "lang",
+                       export_key: :spec
+                     )
+                   end
+    end
+
+    test "builds export info when :export_info_string is specified" do
+      widget =
+        Kino.JS.new(Kino.TestModules.JSExternalAssets, %{spec: %{"width" => 10, "height" => 10}},
+          export_info_string: "vega-lite",
+          export_key: :spec
+        )
+
+      assert %{export: %{info_string: "vega-lite", key: :spec}} = widget
+    end
+
+    test "sets export info to nil when :export_info_string is not specified" do
+      widget =
+        Kino.JS.new(Kino.TestModules.JSExternalAssets, %{spec: %{"width" => 10, "height" => 10}})
+
+      assert %{export: nil} = widget
+    end
+  end
 end


### PR DESCRIPTION
This adds configuration options to enable exporting `Kino.JS` widgets into Live Markdown. Similar to what we already did for Vega-Lite, just generalized.