### PR TITLE
Implement tables with Kino.JS.Live

### DIFF
--- a/lib/assets/data_table/main.css
+++ b/lib/assets/data_table/main.css
@@ -1,0 +1,187 @@
+.app {
+  font-family: "Inter";
+
+  padding: 0px 12px 12px 12px;
+
+  --gray-50: #f8fafc;
+  --gray-100: #f0f5f9;
+  --gray-200: #e1e8f0;
+  --gray-300: #cad5e0;
+  --gray-400: #91a4b7;
+  --gray-500: #61758a;
+  --gray-700: #304254;
+  --gray-800: #1c2a3a;
+}
+
+.navigation {
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+}
+
+.navigation > :not(:first-child) {
+  margin-left: 12px;
+}
+
+.navigation__name {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--gray-800);
+}
+
+.navigation__space {
+  flex-grow: 1;
+}
+
+.pagination {
+  display: flex;
+}
+
+.pagination > :not(:first-child) {
+  margin-left: 8px;
+}
+
+.pagination__button {
+  font-family: inherit;
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: var(--gray-400);
+}
+
+.pagination__button:hover {
+  color: var(--gray-800);
+}
+
+.pagination__button:focus {
+  outline: none;
+}
+
+.pagination__button:disabled {
+  pointer-events: none;
+  color: var(--gray-300);
+}
+
+.pagination__info {
+  padding: 6px 12px;
+  border: 1px solid var(--gray-300);
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--gray-400);
+  border-radius: 8px;
+}
+
+.table-container {
+  box-shadow: 0 0 25px -5px rgba(0, 0, 0, 0.1),
+    0 0 10px -5px rgba(0, 0, 0, 0.04);
+  border-radius: 8px;
+  max-width: 100%;
+  overflow-y: auto;
+}
+
+.table-container--loading {
+  opacity: 0.5;
+  pointer-events: none;
+  transition: opacity 0.25s ease-in-out;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table__row {
+  border-bottom: 1px solid var(--gray-200);
+  white-space: nowrap;
+}
+
+.table__row--hover:hover {
+  background-color: var(--gray-50);
+}
+
+.table__row--no-trailing-border:last-child {
+  border-width: 0;
+}
+
+.table__cell {
+  text-align: left;
+  padding: 12px 24px;
+  color: var(--gray-500);
+}
+
+.table__head .table__cell {
+  color: var(--gray-700);
+  font-width: 600;
+}
+
+.table__cell--clickable {
+  cursor: pointer;
+}
+
+.table__cell-content {
+  display: flex;
+  align-items: center;
+}
+
+.table__cell-content > :not(:first-child) {
+  margin-left: 4px;
+}
+
+.icon-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 100%;
+  color: var(--gray-400);
+  line-height: 1;
+}
+
+.icon-button:hover {
+  color: var(--gray-800);
+}
+
+.icon-button:focus {
+  outline: none;
+  background-color: var(--gray-100);
+}
+
+.icon-button:disabled {
+  color: var(--gray-300);
+  cursor: default;
+}
+
+.no-data {
+  color: var(--gray-700);
+}
+
+.invisible {
+  visibility: hidden;
+}
+
+.ri {
+  font-size: 1.25rem;
+  vertical-align: middle;
+  line-size: 1;
+}
+
+.tiny-scrollbar::-webkit-scrollbar {
+  width: 0.4rem;
+  height: 0.4rem;
+}
+
+.tiny-scrollbar::-webkit-scrollbar-thumb {
+  border-radius: 0.25rem;
+  background-color: var(--gray-400);
+}
+
+.tiny-scrollbar::-webkit-scrollbar-track {
+  background-color: var(--gray-100);
+}

--- a/lib/assets/data_table/main.js
+++ b/lib/assets/data_table/main.js
@@ -1,0 +1,149 @@
+import * as Vue from "https://cdn.jsdelivr.net/npm/vue@3.2.26/dist/vue.esm-browser.prod.js";
+
+export function init(ctx, data) {
+  ctx.importCSS("main.css");
+  ctx.importCSS("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap");
+  ctx.importCSS("https://cdn.jsdelivr.net/npm/remixicon@2.5.0/fonts/remixicon.min.css");
+
+  const app = Vue.createApp({
+    template: `
+      <div class="app">
+        <div class="navigation">
+          <h2 class="navigation__name">
+            {{ data.name }}
+          </h2>
+          <div class="navigation__space"></div>
+          <!-- Actions -->
+          <button
+            v-if="data.features.includes('refetch')"
+            class="icon-button"
+            aria-label="refresh"
+            @click="refetch()"
+          >
+            <remix-icon icon="refresh-line"></remix-icon>
+          </button>
+          <!-- Pagination -->
+          <div
+            v-if="data.features.includes('pagination') && data.content.rows.length > 0"
+            class="pagination"
+          >
+            <button
+              class="pagination__button"
+              @click="prev()"
+              :disabled="data.content.page === 1"
+            >
+              <remix-icon icon="arrow-left-s-line"></remix-icon>
+              <span>Prev</span>
+            </button>
+            <div class="pagination__info">
+              <span>{{ data.content.page }} of {{ data.content.max_page }}</span>
+            </div>
+            <button
+              class="pagination__button"
+              @click="next()"
+              :disabled="data.content.page === data.content.max_page"
+            >
+              <span>Next</span>
+              <remix-icon icon="arrow-right-s-line"></remix-icon>
+            </button>
+          </div>
+        </div>
+
+        <!-- In case we don't have information about table structure yet -->
+        <p v-if="data.content.columns.length === 0" class="no-data">
+          No data
+        </p>
+
+        <!-- Data table -->
+        <div
+          v-else
+          class="table-container tiny-scrollbar"
+          :class="{ 'table-container--loading': loading }"
+        >
+          <table class="table">
+            <thead class="table__head">
+              <tr class="table__row">
+                <th v-for="column in data.content.columns"
+                  :key="column.key"
+                  class="table__cell"
+                  :class="{ 'table__cell--clickable': data.features.includes('sorting') }"
+                  @click="data.features.includes('sorting') && orderBy(column.key)"
+                >
+                  <div class="table__cell-content">
+                    <span>{{ column.label }}</span>
+                    <span :class="{invisible: data.content.order_by !== column.key}">
+                      <remix-icon :icon="data.content.order === 'asc' ? 'arrow-up-s-line' : 'arrow-down-s-line'"></remix-icon>
+                    </span>
+                  </div>
+                </th>
+              </tr>
+            </thead>
+            <tbody class="table__body">
+              <tr v-for="row in data.content.rows" class="table__row table__row--hover table__row--no-trailing-border">
+                <td v-for="column in data.content.columns" :key="column.key" class="table__cell">
+                  {{ row.fields[column.key] }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    `,
+
+    data() {
+      return {
+        data,
+        loading: false,
+      };
+    },
+
+    methods: {
+      prev() {
+        this.loading = true;
+        ctx.pushEvent("show_page", { page: this.data.content.page - 1 });
+      },
+
+      next() {
+        this.loading = true;
+        ctx.pushEvent("show_page", { page: this.data.content.page + 1 });
+      },
+
+      refetch() {
+        this.loading = true;
+        ctx.pushEvent("refetch");
+      },
+
+      orderBy(newKey) {
+        this.loading = true;
+        const [key, order] = reorder(this.data.content.order_by, this.data.content.order, newKey)
+        ctx.pushEvent("order_by", { key, order });
+      },
+    },
+
+    components: {
+      RemixIcon: {
+        props: ["icon"],
+        template: `
+          <i :class="'ri ri-' + icon" aria-hidden="true"></i>
+        `
+      }
+    }
+  }).mount(ctx.root);
+
+  ctx.handleEvent("update_content", (content) => {
+    app.data.content = content;
+    app.loading = false;
+  });
+}
+
+function reorder(orderBy, order, key) {
+  if (orderBy === key) {
+    if (order === "asc") {
+      return [key, "desc"];
+    } else {
+      return [null, "asc"];
+    }
+  } else {
+    return [key, "asc"]
+  }
+}

--- a/lib/kino/output.ex
+++ b/lib/kino/output.ex
@@ -16,7 +16,6 @@ defmodule Kino.Output do
           | image()
           | js_static()
           | js_dynamic()
-          | table_dynamic()
           | frame_dynamic()
           | input()
           | control()
@@ -123,60 +122,6 @@ defmodule Kino.Output do
                 key: nil | term()
               }
         }
-
-  @typedoc """
-  Interactive data table.
-
-  This output points to a server process that serves data requests,
-  handling filtering, sorting and slicing data as necessary.
-
-  ## Communication protocol
-
-  A client process should connect to the server process by sending:
-
-      {:connect, pid()}
-
-  And expect the following reply:
-
-      @type column :: %{
-        key: term(),
-        label: binary()
-      }
-
-      {:connect_reply, %{
-        name: binary(),
-        columns: list(column()),
-        features: list(:refetch | :pagination | :sorting)
-      }}
-
-  The client may then query for table rows by sending the following requests:
-
-      @type rows_spec :: %{
-        offset: non_neg_integer(),
-        limit: pos_integer(),
-        order_by: nil | term(),
-        order: :asc | :desc,
-      }
-
-      {:get_rows, pid(), rows_spec()}
-
-  To which the server responds with retrieved data:
-
-      @type row :: %{
-        # An identifier, opaque to the client
-        ref: term(),
-        # A string value for every column key
-        fields: list(%{term() => binary()})
-      }
-
-      {:rows, %{
-        rows: list(row()),
-        total_rows: non_neg_integer(),
-        # Possibly an updated columns specification
-        columns: :initial | list(column())
-      }}
-  """
-  @type table_dynamic :: {:table_dynamic, pid()}
 
   @typedoc """
   Animable output.
@@ -396,14 +341,6 @@ defmodule Kino.Output do
   @spec js_dynamic(js_info(), pid()) :: t()
   def js_dynamic(info, pid) when is_map(info) and is_pid(pid) do
     {:js_dynamic, info, pid}
-  end
-
-  @doc """
-  See `t:table_dynamic/0`.
-  """
-  @spec table_dynamic(pid()) :: t()
-  def table_dynamic(pid) when is_pid(pid) do
-    {:table_dynamic, pid}
   end
 
   @doc """

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -35,20 +35,6 @@ defimpl Kino.Render, for: Kino.JS.Live do
   end
 end
 
-defimpl Kino.Render, for: Kino.ETS do
-  def to_livebook(widget) do
-    Kino.Bridge.reference_object(widget.pid, self())
-    Kino.Output.table_dynamic(widget.pid)
-  end
-end
-
-defimpl Kino.Render, for: Kino.DataTable do
-  def to_livebook(widget) do
-    Kino.Bridge.reference_object(widget.pid, self())
-    Kino.Output.table_dynamic(widget.pid)
-  end
-end
-
 defimpl Kino.Render, for: Kino.Image do
   def to_livebook(image) do
     Kino.Output.image(image.content, image.mime_type)
@@ -58,13 +44,6 @@ end
 defimpl Kino.Render, for: Kino.Markdown do
   def to_livebook(markdown) do
     Kino.Output.markdown(markdown.content)
-  end
-end
-
-defimpl Kino.Render, for: Kino.Ecto do
-  def to_livebook(widget) do
-    Kino.Bridge.reference_object(widget.pid, self())
-    Kino.Output.table_dynamic(widget.pid)
   end
 end
 

--- a/lib/kino/table.ex
+++ b/lib/kino/table.ex
@@ -1,0 +1,177 @@
+defmodule Kino.Table do
+  @moduledoc false
+
+  @type info :: %{
+          name: String.t(),
+          features: list(:refetch | :pagination | :sorting)
+        }
+
+  @type rows_spec :: %{
+          offset: non_neg_integer(),
+          limit: pos_integer(),
+          order_by: nil | term(),
+          order: :asc | :desc
+        }
+
+  @type column :: %{
+          key: term(),
+          label: binary()
+        }
+
+  @type row :: %{
+          # A string value for every column key
+          fields: list(%{term() => binary()})
+        }
+
+  @type state :: term()
+
+  @doc """
+  Invoked once to initialize server state.
+  """
+  @callback init(init_arg :: term()) :: {:ok, info(), state()}
+
+  @doc """
+  Loads data matching the given specification.
+  """
+  @callback get_data(rows_spec(), state()) ::
+              {:ok,
+               %{
+                 columns: list(column()),
+                 rows: list(row()),
+                 total_rows: non_neg_integer()
+               }, state()}
+
+  use Kino.JS, assets_path: "lib/assets/data_table"
+  use Kino.JS.Live
+
+  @type t :: Kino.JS.Live.t()
+
+  @limit 10
+
+  def new(module, init_arg) do
+    Kino.JS.Live.new(__MODULE__, {module, init_arg})
+  end
+
+  @impl true
+  def init({module, init_arg}, ctx) do
+    {:ok, info, state} = module.init(init_arg)
+
+    {:ok,
+     assign(ctx,
+       module: module,
+       info: info,
+       state: state,
+       key_to_string: %{},
+       content: nil,
+       # Data specification
+       page: 1,
+       limit: @limit,
+       order_by: nil,
+       order: :asc
+     )}
+  end
+
+  @impl true
+  def handle_connect(ctx) do
+    ctx =
+      if ctx.assigns.content do
+        ctx
+      else
+        {content, ctx} = get_content(ctx)
+        assign(ctx, content: content)
+      end
+
+    payload = %{
+      name: ctx.assigns.info.name,
+      features: ctx.assigns.info.features,
+      content: ctx.assigns.content
+    }
+
+    {:ok, payload, ctx}
+  end
+
+  @impl true
+  def handle_event("show_page", %{"page" => page}, ctx) do
+    {:noreply, ctx |> assign(page: page) |> broadcast_update()}
+  end
+
+  def handle_event("refetch", _payload, ctx) do
+    {:noreply, broadcast_update(ctx)}
+  end
+
+  def handle_event("order_by", %{"key" => key_string, "order" => order}, ctx) do
+    order = String.to_existing_atom(order)
+
+    ctx =
+      if key_string do
+        # Lookup key by the string representation received from the client
+        ctx.assigns.key_to_string
+        |> Enum.find(&match?({_key, ^key_string}, &1))
+        |> case do
+          {key, _key_string} -> assign(ctx, order_by: key, order: order)
+          _ -> ctx
+        end
+      else
+        assign(ctx, order_by: nil, order: :asc)
+      end
+
+    {:noreply, broadcast_update(ctx)}
+  end
+
+  defp broadcast_update(ctx) do
+    {content, ctx} = get_content(ctx)
+    ctx = assign(ctx, content: content)
+    broadcast_event(ctx, "update_content", content)
+  end
+
+  defp get_content(ctx) do
+    rows_spec = %{
+      offset: (ctx.assigns.page - 1) * ctx.assigns.limit,
+      limit: ctx.assigns.limit,
+      order_by: ctx.assigns.order_by,
+      order: ctx.assigns.order
+    }
+
+    {:ok, %{columns: columns, rows: rows, total_rows: total_rows}, state} =
+      ctx.assigns.module.get_data(rows_spec, ctx.assigns.state)
+
+    {columns, rows, key_to_string} = stringify_keys(columns, rows, ctx.assigns.key_to_string)
+
+    ctx = assign(ctx, state: state, key_to_string: key_to_string)
+
+    content = %{
+      rows: rows,
+      columns: columns,
+      page: ctx.assigns.page,
+      max_page: ceil(total_rows / ctx.assigns.limit),
+      order: ctx.assigns.order,
+      order_by: key_to_string[ctx.assigns.order_by]
+    }
+
+    {content, ctx}
+  end
+
+  # Map keys to string representation for the client side
+  defp stringify_keys(columns, rows, key_to_string) do
+    {columns, key_to_string} =
+      Enum.map_reduce(columns, key_to_string, fn column, key_to_string ->
+        key_to_string =
+          Map.put_new_lazy(key_to_string, column.key, fn ->
+            key_to_string |> map_size() |> Integer.to_string()
+          end)
+
+        column = %{column | key: key_to_string[column.key]}
+
+        {column, key_to_string}
+      end)
+
+    rows =
+      update_in(rows, [Access.all(), :fields], fn fields ->
+        Map.new(fields, fn {key, value} ->
+          {key_to_string[key], value}
+        end)
+      end)
+
+    {columns, rows, key_to_string}
+  end
+end

--- a/test/kino/ecto_test.exs
+++ b/test/kino/ecto_test.exs
@@ -13,104 +13,7 @@ defmodule Kino.EctoTest do
     end
   end
 
-  defmodule User do
-    use Ecto.Schema
-
-    schema "users" do
-      field(:name, :string)
-
-      timestamps()
-    end
-  end
-
-  describe "connecting" do
-    test "connect reply contains columns definition if a schema is given" do
-      widget = Kino.Ecto.new(User, MockRepo)
-
-      send(widget.pid, {:connect, self()})
-
-      assert_receive {:connect_reply,
-                      %{
-                        name: "users",
-                        columns: [
-                          %{key: :id, label: ":id"},
-                          %{key: :name, label: ":name"},
-                          %{key: :inserted_at, label: ":inserted_at"},
-                          %{key: :updated_at, label: ":updated_at"}
-                        ],
-                        features: _features
-                      }}
-    end
-
-    test "connect reply contains columns definition if a query with schema source is given" do
-      query = from(u in User, where: like(u.name, "%Jake%"))
-      widget = Kino.Ecto.new(query, MockRepo)
-
-      send(widget.pid, {:connect, self()})
-
-      assert_receive {:connect_reply,
-                      %{
-                        name: "users",
-                        columns: [
-                          %{key: :id, label: ":id"},
-                          %{key: :name, label: ":name"},
-                          %{key: :inserted_at, label: ":inserted_at"},
-                          %{key: :updated_at, label: ":updated_at"}
-                        ],
-                        features: _features
-                      }}
-    end
-
-    test "connect reply contains empty columns if a query without schema is given" do
-      query = from(u in "users", where: like(u.name, "%Jake%"))
-      widget = Kino.Ecto.new(query, MockRepo)
-
-      send(widget.pid, {:connect, self()})
-
-      assert_receive {:connect_reply,
-                      %{
-                        name: "users",
-                        columns: [],
-                        features: _features
-                      }}
-    end
-
-    test "connect reply contains empty columns if a query with custom select is given" do
-      query = from(u in User, select: {u.id, u.name})
-      widget = Kino.Ecto.new(query, MockRepo)
-
-      send(widget.pid, {:connect, self()})
-
-      assert_receive {:connect_reply,
-                      %{
-                        name: "users",
-                        columns: [],
-                        features: _features
-                      }}
-    end
-
-    test "sorting is enabled when a regular query is given" do
-      query = from(u in User, where: like(u.name, "%Jake%"))
-      widget = Kino.Ecto.new(query, MockRepo)
-
-      send(widget.pid, {:connect, self()})
-
-      assert_receive {:connect_reply, %{features: [:refetch, :pagination, :sorting]}}
-    end
-
-    test "sorting is disabled when a query with custom select is given" do
-      query = from(u in User, where: like(u.name, "%Jake%"), select: {u.id, u.name})
-      widget = Kino.Ecto.new(query, MockRepo)
-
-      send(widget.pid, {:connect, self()})
-
-      assert_receive {:connect_reply, %{features: [:refetch, :pagination]}}
-    end
-  end
-
   defmodule MockRepo do
-    @moduledoc false
-
     # Allows tests to verify or refute that a query was run
     # and also substitute the final result
 
@@ -150,211 +53,255 @@ defmodule Kino.EctoTest do
     end
   end
 
-  describe "querying rows" do
-    test "returns rows received from repo" do
-      widget = Kino.Ecto.new(User, MockRepo)
-      connect_self(widget)
+  defmodule User do
+    use Ecto.Schema
 
-      spec = %{offset: 0, limit: 10, order_by: nil, order: :asc}
+    schema "users" do
+      field(:name, :string)
 
-      MockRepo.subscribe()
-
-      send(widget.pid, {:get_rows, self(), spec})
-
-      assert_receive {from, [MockRepo, :aggregate, query: _, aggregate: :count, opts: []]}
-      MockRepo.resolve_call(from, 3)
-
-      users = [
-        %User{
-          id: 1,
-          name: "Amy Santiago",
-          inserted_at: DateTime.utc_now(),
-          updated_at: DateTime.utc_now()
-        },
-        %User{
-          id: 2,
-          name: "Jake Peralta",
-          inserted_at: DateTime.utc_now(),
-          updated_at: DateTime.utc_now()
-        },
-        %User{
-          id: 3,
-          name: "Terry Jeffords",
-          inserted_at: DateTime.utc_now(),
-          updated_at: DateTime.utc_now()
-        }
-      ]
-
-      assert_receive {from, [MockRepo, :all, query: _, opts: []]}
-      MockRepo.resolve_call(from, users)
-
-      assert_receive {:rows,
-                      %{
-                        rows: [
-                          %{
-                            id: _,
-                            fields: %{
-                              id: "1",
-                              name: ~s/"Amy Santiago"/,
-                              inserted_at: _,
-                              updated_at: _
-                            }
-                          },
-                          %{
-                            id: _,
-                            fields: %{
-                              id: "2",
-                              name: ~s/"Jake Peralta"/,
-                              inserted_at: _,
-                              updated_at: _
-                            }
-                          },
-                          %{
-                            id: _,
-                            fields: %{
-                              id: "3",
-                              name: ~s/"Terry Jeffords"/,
-                              inserted_at: _,
-                              updated_at: _
-                            }
-                          }
-                        ],
-                        total_rows: 3,
-                        columns: _columns
-                      }}
-    end
-
-    test "query limit and offset are overridden" do
-      query = from(u in User, offset: 2, limit: 2)
-      widget = Kino.Ecto.new(query, MockRepo)
-      connect_self(widget)
-
-      spec = %{offset: 0, limit: 10, order_by: nil, order: :asc}
-
-      MockRepo.subscribe()
-
-      send(widget.pid, {:get_rows, self(), spec})
-
-      assert_receive {from, [MockRepo, :aggregate, query: _, aggregate: :count, opts: []]}
-      MockRepo.resolve_call(from, 0)
-
-      assert_receive {from, [MockRepo, :all, query: %{offset: offset, limit: limit}, opts: []]}
-      MockRepo.resolve_call(from, [])
-
-      assert Macro.to_string(offset.expr) == "^0"
-      assert offset.params == [{0, :integer}]
-      assert Macro.to_string(limit.expr) == "^0"
-      assert limit.params == [{10, :integer}]
-    end
-
-    test "query order by is kept if request doesn't specify any" do
-      query = from(u in User, order_by: u.name)
-      widget = Kino.Ecto.new(query, MockRepo)
-      connect_self(widget)
-
-      spec = %{offset: 0, limit: 10, order_by: nil, order: :asc}
-
-      MockRepo.subscribe()
-
-      send(widget.pid, {:get_rows, self(), spec})
-
-      assert_receive {from, [MockRepo, :aggregate, query: _, aggregate: :count, opts: []]}
-      MockRepo.resolve_call(from, 0)
-
-      assert_receive {from, [MockRepo, :all, query: %{order_bys: [order_by]}, opts: []]}
-      MockRepo.resolve_call(from, [])
-
-      assert Macro.to_string(order_by.expr) == "[asc: &0.name()]"
-    end
-
-    test "query order by is overriden if specified in the request" do
-      query = from(u in User, order_by: u.name)
-      widget = Kino.Ecto.new(query, MockRepo)
-      connect_self(widget)
-
-      spec = %{offset: 0, limit: 10, order_by: :id, order: :desc}
-
-      MockRepo.subscribe()
-
-      send(widget.pid, {:get_rows, self(), spec})
-
-      assert_receive {from, [MockRepo, :aggregate, query: _, aggregate: :count, opts: []]}
-      MockRepo.resolve_call(from, 0)
-
-      assert_receive {from, [MockRepo, :all, query: %{order_bys: [order_by]}, opts: []]}
-      MockRepo.resolve_call(from, [])
-
-      assert Macro.to_string(order_by.expr) == "[desc: &0.id()]"
-    end
-
-    test "handles custom select results" do
-      query = from(u in User, select: {u.id, u.name})
-      widget = Kino.Ecto.new(query, MockRepo)
-      connect_self(widget)
-
-      spec = %{offset: 0, limit: 10, order_by: :id, order: :desc}
-
-      MockRepo.subscribe()
-
-      send(widget.pid, {:get_rows, self(), spec})
-
-      assert_receive {from, [MockRepo, :aggregate, query: _, aggregate: :count, opts: []]}
-      MockRepo.resolve_call(from, 3)
-
-      data = [{1, "Amy Santiago"}, {2, "Jake Peralta"}]
-
-      assert_receive {from, [MockRepo, :all, query: _, opts: []]}
-      MockRepo.resolve_call(from, data)
-
-      assert_receive {:rows,
-                      %{
-                        rows: [
-                          %{id: _, fields: %{0 => "1", 1 => ~s/"Amy Santiago"/}},
-                          %{id: _, fields: %{0 => "2", 1 => ~s/"Jake Peralta"/}}
-                        ],
-                        total_rows: 3,
-                        columns: [
-                          %{key: 0, label: "0"},
-                          %{key: 1, label: "1"}
-                        ]
-                      }}
-    end
-
-    test "handles a list of atomic items" do
-      query = from(u in User, select: u.name)
-      widget = Kino.Ecto.new(query, MockRepo)
-      connect_self(widget)
-
-      spec = %{offset: 0, limit: 10, order_by: :id, order: :desc}
-
-      MockRepo.subscribe()
-
-      send(widget.pid, {:get_rows, self(), spec})
-
-      assert_receive {from, [MockRepo, :aggregate, query: _, aggregate: :count, opts: []]}
-      MockRepo.resolve_call(from, 3)
-
-      data = ["Amy Santiago", "Jake Peralta"]
-
-      assert_receive {from, [MockRepo, :all, query: _, opts: []]}
-      MockRepo.resolve_call(from, data)
-
-      assert_receive {:rows,
-                      %{
-                        rows: [
-                          %{id: _, fields: %{:item => ~s/"Amy Santiago"/}},
-                          %{id: _, fields: %{:item => ~s/"Jake Peralta"/}}
-                        ],
-                        total_rows: 3,
-                        columns: [
-                          %{key: :item, label: ":item"}
-                        ]
-                      }}
+      timestamps()
     end
   end
 
-  defp connect_self(widget) do
-    send(widget.pid, {:connect, self()})
-    assert_receive {:connect_reply, %{}}
+  test "content contains columns definition if a schema is given" do
+    widget = Kino.Ecto.new(User, MockRepo)
+
+    MockRepo.subscribe()
+    async_connect_self(widget)
+    resolve_table_queries(MockRepo, [])
+    data = await_connect_self()
+
+    assert %{
+             content: %{
+               columns: [
+                 %{key: "0", label: ":id"},
+                 %{key: "1", label: ":name"},
+                 %{key: "2", label: ":inserted_at"},
+                 %{key: "3", label: ":updated_at"}
+               ],
+               rows: []
+             }
+           } = data
+  end
+
+  test "connect contains columns definition if a query with schema source is given" do
+    query = from(u in User, where: like(u.name, "%Jake%"))
+    widget = Kino.Ecto.new(query, MockRepo)
+
+    MockRepo.subscribe()
+    async_connect_self(widget)
+    resolve_table_queries(MockRepo, [])
+    data = await_connect_self()
+
+    assert %{
+             content: %{
+               columns: [
+                 %{key: "0", label: ":id"},
+                 %{key: "1", label: ":name"},
+                 %{key: "2", label: ":inserted_at"},
+                 %{key: "3", label: ":updated_at"}
+               ],
+               rows: []
+             }
+           } = data
+  end
+
+  test "content contains empty columns if a query without schema is given and there are no rows" do
+    query = from(u in "users", where: like(u.name, "%Jake%"))
+    widget = Kino.Ecto.new(query, MockRepo)
+
+    MockRepo.subscribe()
+    async_connect_self(widget)
+    resolve_table_queries(MockRepo, [])
+    data = await_connect_self()
+
+    assert %{content: %{columns: [], rows: []}} = data
+  end
+
+  test "sorting is enabled when a regular query is given" do
+    query = from(u in User, where: like(u.name, "%Jake%"))
+    widget = Kino.Ecto.new(query, MockRepo)
+
+    MockRepo.subscribe()
+    async_connect_self(widget)
+    resolve_table_queries(MockRepo, [])
+    data = await_connect_self()
+
+    assert %{features: [:refetch, :pagination, :sorting]} = data
+  end
+
+  test "sorting is disabled when a query with custom select is given" do
+    query = from(u in User, where: like(u.name, "%Jake%"), select: {u.id, u.name})
+    widget = Kino.Ecto.new(query, MockRepo)
+
+    MockRepo.subscribe()
+    async_connect_self(widget)
+    resolve_table_queries(MockRepo, [])
+    data = await_connect_self()
+
+    assert %{features: [:refetch, :pagination]} = data
+  end
+
+  test "returns rows received from repo" do
+    widget = Kino.Ecto.new(User, MockRepo)
+
+    users = [
+      %User{
+        id: 1,
+        name: "Amy Santiago",
+        inserted_at: DateTime.utc_now(),
+        updated_at: DateTime.utc_now()
+      },
+      %User{
+        id: 2,
+        name: "Jake Peralta",
+        inserted_at: DateTime.utc_now(),
+        updated_at: DateTime.utc_now()
+      },
+      %User{
+        id: 3,
+        name: "Terry Jeffords",
+        inserted_at: DateTime.utc_now(),
+        updated_at: DateTime.utc_now()
+      }
+    ]
+
+    MockRepo.subscribe()
+    async_connect_self(widget)
+    resolve_table_queries(MockRepo, users)
+    data = await_connect_self()
+
+    assert %{
+             name: "users",
+             features: _features,
+             content: %{
+               columns: [
+                 %{key: "0", label: ":id"},
+                 %{key: "1", label: ":name"},
+                 %{key: "2", label: ":inserted_at"},
+                 %{key: "3", label: ":updated_at"}
+               ],
+               rows: [
+                 %{fields: %{"0" => "1", "1" => ~s/"Amy Santiago"/, "2" => _, "3" => _}},
+                 %{fields: %{"0" => "2", "1" => ~s/"Jake Peralta"/, "2" => _, "3" => _}},
+                 %{fields: %{"0" => "3", "1" => ~s/"Terry Jeffords"/, "2" => _, "3" => _}}
+               ],
+               page: 1,
+               max_page: 1,
+               order_by: nil,
+               order: :asc
+             }
+           } = data
+  end
+
+  test "query limit and offset are overridden" do
+    query = from(u in User, offset: 2, limit: 2)
+    widget = Kino.Ecto.new(query, MockRepo)
+
+    MockRepo.subscribe()
+    async_connect_self(widget)
+    %{all_query: %{offset: offset, limit: limit}} = resolve_table_queries(MockRepo, [])
+
+    assert Macro.to_string(offset.expr) == "^0"
+    assert offset.params == [{0, :integer}]
+    assert Macro.to_string(limit.expr) == "^0"
+    assert limit.params == [{10, :integer}]
+  end
+
+  test "query order by is kept if request doesn't specify any" do
+    query = from(u in User, order_by: u.name)
+    widget = Kino.Ecto.new(query, MockRepo)
+
+    MockRepo.subscribe()
+    async_connect_self(widget)
+    %{all_query: %{order_bys: [order_by]}} = resolve_table_queries(MockRepo, [])
+
+    assert Macro.to_string(order_by.expr) == "[asc: &0.name()]"
+  end
+
+  test "query order by is overridden if specified in the request" do
+    query = from(u in User, order_by: u.name)
+    widget = Kino.Ecto.new(query, MockRepo)
+
+    MockRepo.subscribe()
+    async_connect_self(widget)
+    resolve_table_queries(MockRepo, [])
+
+    send(
+      widget.pid,
+      {:event, "order_by", %{"key" => "0", "order" => "desc"}, %{origin: self()}}
+    )
+
+    %{all_query: %{order_bys: [order_by]}} = resolve_table_queries(MockRepo, [])
+
+    assert Macro.to_string(order_by.expr) == "[desc: &0.id()]"
+  end
+
+  test "handles custom select results" do
+    query = from(u in User, select: {u.id, u.name})
+    widget = Kino.Ecto.new(query, MockRepo)
+
+    results = [{1, "Amy Santiago"}, {2, "Jake Peralta"}]
+
+    MockRepo.subscribe()
+    async_connect_self(widget)
+    resolve_table_queries(MockRepo, results)
+    data = await_connect_self()
+
+    assert %{
+             content: %{
+               columns: [
+                 %{key: "0", label: "0"},
+                 %{key: "1", label: "1"}
+               ],
+               rows: [
+                 %{fields: %{"0" => "1", "1" => ~s/"Amy Santiago"/}},
+                 %{fields: %{"0" => "2", "1" => ~s/"Jake Peralta"/}}
+               ]
+             }
+           } = data
+  end
+
+  test "handles a list of atomic items" do
+    query = from(u in User, select: u.name)
+    widget = Kino.Ecto.new(query, MockRepo)
+
+    results = ["Amy Santiago", "Jake Peralta"]
+
+    MockRepo.subscribe()
+    async_connect_self(widget)
+    resolve_table_queries(MockRepo, results)
+    data = await_connect_self()
+
+    assert %{
+             content: %{
+               columns: [
+                 %{key: "0", label: ":item"}
+               ],
+               rows: [
+                 %{fields: %{"0" => ~s/"Amy Santiago"/}},
+                 %{fields: %{"0" => ~s/"Jake Peralta"/}}
+               ]
+             }
+           } = data
+  end
+
+  defp async_connect_self(widget) do
+    send(widget.pid, {:connect, self(), %{origin: self()}})
+  end
+
+  defp await_connect_self() do
+    assert_receive {:connect_reply, %{} = data}
+    data
+  end
+
+  defp resolve_table_queries(repo, results) do
+    assert_receive {from, [^repo, :aggregate, query: count_query, aggregate: :count, opts: []]}
+    MockRepo.resolve_call(from, length(results))
+
+    assert_receive {from, [^repo, :all, query: all_query, opts: []]}
+    MockRepo.resolve_call(from, results)
+
+    %{count_query: count_query, all_query: all_query}
   end
 end


### PR DESCRIPTION
This changes the underlying implementation of `Kino.DataTable`, `Kino.ETS` and `Kino.Ecto` to JavaScript widgets, instead of the specific `:data_table` output we currently have. This removes another bit from the Kino-Livebook contract, which also means we can more easily change the tables behaviour in the future.

The public API doesn't change. The only difference is that the table state is now synchronized across uses, which we intended to do anyway.

https://user-images.githubusercontent.com/17034772/147990052-fb3c21f3-60f5-46d6-bbd0-b9a52e826540.mp4

I introduced a `Kino.Table` abstraction that builds on top of `Kino.JS.Live`, but I'd keep it private for now.