### PR TITLE
Add reference to JavaScript outputs and messages

### DIFF
--- a/lib/kino/application.ex
+++ b/lib/kino/application.ex
@@ -7,6 +7,7 @@ defmodule Kino.Application do
     children = [
       {DynamicSupervisor, strategy: :one_for_one, name: Kino.DynamicSupervisor},
       Kino.SubscriptionManager,
+      Kino.JSDataStore,
       Kino.Terminator
     ]
 

--- a/lib/kino/js.ex
+++ b/lib/kino/js.ex
@@ -148,9 +148,9 @@ defmodule Kino.JS do
   interaction, see `Kino.JS.Live` as a next step in our discussion.
   '''
 
-  defstruct [:module, :data, :ref, :export]
+  defstruct [:module, :ref, :export]
 
-  @type t :: %__MODULE__{module: module(), data: term(), ref: String.t(), export: map()}
+  @type t :: %__MODULE__{module: module(), ref: String.t(), export: map()}
 
   defmacro __using__(opts) do
     quote location: :keep, bind_quoted: [opts: opts] do
@@ -400,7 +400,12 @@ defmodule Kino.JS do
 
     ref = System.unique_integer() |> Integer.to_string()
 
-    %__MODULE__{module: module, data: data, ref: ref, export: export}
+    Kino.JSDataStore.store(ref, data)
+
+    Kino.Bridge.reference_object(ref, self())
+    Kino.Bridge.monitor_object(ref, Kino.JSDataStore, {:remove, ref})
+
+    %__MODULE__{module: module, ref: ref, export: export}
   end
 
   @doc false

--- a/lib/kino/js.ex
+++ b/lib/kino/js.ex
@@ -148,9 +148,9 @@ defmodule Kino.JS do
   interaction, see `Kino.JS.Live` as a next step in our discussion.
   '''
 
-  defstruct [:module, :data, :export]
+  defstruct [:module, :data, :ref, :export]
 
-  @type t :: %__MODULE__{module: module(), data: term()}
+  @type t :: %__MODULE__{module: module(), data: term(), ref: String.t(), export: map()}
 
   defmacro __using__(opts) do
     quote location: :keep, bind_quoted: [opts: opts] do
@@ -398,13 +398,16 @@ defmodule Kino.JS do
         %{info_string: info_string, key: export_key}
       end
 
-    %__MODULE__{module: module, data: data, export: export}
+    ref = System.unique_integer() |> Integer.to_string()
+
+    %__MODULE__{module: module, data: data, ref: ref, export: export}
   end
 
   @doc false
   @spec js_info(t()) :: Kino.Output.js_info()
   def js_info(%__MODULE__{} = widget) do
     %{
+      ref: widget.ref,
       assets: widget.module.__assets_info__(),
       export: widget.export
     }

--- a/lib/kino/js.ex
+++ b/lib/kino/js.ex
@@ -413,6 +413,7 @@ defmodule Kino.JS do
   def js_info(%__MODULE__{} = widget) do
     %{
       ref: widget.ref,
+      pid: Kino.JSDataStore.cross_node_name(),
       assets: widget.module.__assets_info__(),
       export: widget.export
     }

--- a/lib/kino/js/live.ex
+++ b/lib/kino/js/live.ex
@@ -127,11 +127,11 @@ defmodule Kino.JS.Live do
   the handler is registered.
   '''
 
-  defstruct [:module, :pid]
+  defstruct [:module, :pid, :ref]
 
   alias Kino.JS.Live.Context
 
-  @type t :: %__MODULE__{module: module(), pid: pid()}
+  @type t :: %__MODULE__{module: module(), pid: pid(), ref: String.t()}
 
   @doc """
   Invoked when the widget server started.
@@ -225,14 +225,16 @@ defmodule Kino.JS.Live do
   """
   @spec new(module(), term()) :: t()
   def new(module, init_arg) do
-    {:ok, pid} = Kino.start_child({Kino.JS.LiveServer, {module, init_arg}})
-    %__MODULE__{module: module, pid: pid}
+    ref = System.unique_integer() |> Integer.to_string()
+    {:ok, pid} = Kino.start_child({Kino.JS.LiveServer, {module, init_arg, ref}})
+    %__MODULE__{module: module, pid: pid, ref: ref}
   end
 
   @doc false
   @spec js_info(t()) :: Kino.Output.js_info()
   def js_info(%__MODULE__{} = widget) do
     %{
+      ref: widget.ref,
       assets: widget.module.__assets_info__(),
       export: nil
     }

--- a/lib/kino/js/live.ex
+++ b/lib/kino/js/live.ex
@@ -235,6 +235,7 @@ defmodule Kino.JS.Live do
   def js_info(%__MODULE__{} = widget) do
     %{
       ref: widget.ref,
+      pid: widget.pid,
       assets: widget.module.__assets_info__(),
       export: nil
     }

--- a/lib/kino/js/live_server.ex
+++ b/lib/kino/js/live_server.ex
@@ -17,15 +17,16 @@ defmodule Kino.JS.LiveServer do
 
   def broadcast_event(ctx, event, payload) do
     for pid <- ctx.__private__.client_pids do
-      send(pid, {:event, event, payload})
+      send(pid, {:event, event, payload, %{ref: ctx.__private__.ref}})
     end
 
     :ok
   end
 
   @impl true
-  def init({module, init_arg}) do
+  def init({module, init_arg, ref}) do
     ctx = Context.new()
+    ctx = put_in(ctx.__private__[:ref], ref)
 
     {:ok, ctx} =
       if has_function?(module, :init, 2) do
@@ -60,7 +61,7 @@ defmodule Kino.JS.LiveServer do
     {:ok, data, ctx} = state.module.handle_connect(ctx)
     ctx = %{ctx | origin: nil}
 
-    send(pid, {:connect_reply, data})
+    send(pid, {:connect_reply, data, %{ref: state.ctx.__private__.ref}})
 
     {:noreply, %{state | ctx: ctx}}
   end

--- a/lib/kino/js_data_store.ex
+++ b/lib/kino/js_data_store.ex
@@ -1,0 +1,54 @@
+defmodule Kino.JSDataStore do
+  @moduledoc false
+
+  # Process responsible for keeping the data for static
+  # JS outputs. Unlike JS.Live widgets, plain JS widgets
+  # have no server, so we use a single process for storing
+  # their data and replying to data queries.
+
+  use GenServer
+
+  @name __MODULE__
+
+  def cross_node_name() do
+    {@name, node()}
+  end
+
+  @doc """
+  Starts the data store.
+  """
+  def start_link(_opts \\ []) do
+    GenServer.start_link(__MODULE__, {}, name: @name)
+  end
+
+  @doc """
+  Stores output data under the given ref.
+  """
+  @spec store(Kino.Output.js_output_ref(), term()) :: :ok
+  def store(ref, data) do
+    GenServer.cast(@name, {:store, ref, data})
+  end
+
+  @impl true
+  def init({}) do
+    {:ok, %{ref_with_data: %{}}}
+  end
+
+  @impl true
+  def handle_cast({:store, ref, data}, state) do
+    {:noreply, put_in(state.ref_with_data[ref], data)}
+  end
+
+  @impl true
+  def handle_info({:connect, pid, %{origin: _origin, ref: ref}}, state) do
+    data = state.ref_with_data[ref]
+    send(pid, {:connect_reply, data, %{ref: ref}})
+
+    {:noreply, state}
+  end
+
+  def handle_info({:remove, ref}, state) do
+    {_, state} = pop_in(state.ref_with_data[ref])
+    {:noreply, state}
+  end
+end

--- a/lib/kino/output.ex
+++ b/lib/kino/output.ex
@@ -14,7 +14,6 @@ defmodule Kino.Output do
           | text_block()
           | markdown()
           | image()
-          | js_static()
           | js_dynamic()
           | frame_dynamic()
           | input()
@@ -46,16 +45,6 @@ defmodule Kino.Output do
   @type image :: {:image, content :: binary(), mime_type :: binary()}
 
   @typedoc """
-  JavaScript powered output with static data.
-
-  When rendered, the specified JS is invoked with the given data
-  and can freely manipulate document tree in the output element.
-
-  See `Kino.JS` for more details.
-  """
-  @type js_static() :: {:js_static, info :: js_info(), data :: term()}
-
-  @typedoc """
   JavaScript powered output with dynamic data and events.
 
   This output points to a server process that serves data requests
@@ -65,7 +54,7 @@ defmodule Kino.Output do
 
   A client process should connect to the server process by sending:
 
-      {:connect, pid(), info :: %{origin: term()}}
+      {:connect, pid(), info :: %{ref: js_output_ref(), origin: term()}}
 
   And expect the following reply:
 
@@ -77,7 +66,7 @@ defmodule Kino.Output do
 
   The client process may keep sending one of the following events:
 
-      {:event, event :: String.t(), payload :: term(), info :: %{origin: term()}}
+      {:event, event :: String.t(), payload :: term(), info :: %{ref: js_output_ref(), origin: term()}}
 
   See `Kino.JS` and `Kino.JS.Live` for more details.
   """
@@ -333,18 +322,10 @@ defmodule Kino.Output do
   end
 
   @doc """
-  See `t:js_static/0`.
-  """
-  @spec js_static(js_info(), term()) :: t()
-  def js_static(info, data) when is_map(info) do
-    {:js_static, info, data}
-  end
-
-  @doc """
   See `t:js_dynamic/0`.
   """
-  @spec js_dynamic(js_info(), pid()) :: t()
-  def js_dynamic(info, pid) when is_map(info) and is_pid(pid) do
+  @spec js_dynamic(js_info(), Process.dest()) :: t()
+  def js_dynamic(info, pid) when is_map(info) do
     {:js_dynamic, info, pid}
   end
 

--- a/lib/kino/output.ex
+++ b/lib/kino/output.ex
@@ -14,7 +14,7 @@ defmodule Kino.Output do
           | text_block()
           | markdown()
           | image()
-          | js_dynamic()
+          | js()
           | frame_dynamic()
           | input()
           | control()
@@ -70,12 +70,14 @@ defmodule Kino.Output do
 
   See `Kino.JS` and `Kino.JS.Live` for more details.
   """
-  @type js_dynamic() :: {:js_dynamic, info :: js_info(), pid()}
+  @type js() :: {:js, info :: js_info()}
 
   @typedoc """
   Data describing a custom JS output component.
 
     * `:ref` - unique output identifier
+
+    * `:pid` - the server process holding the data
 
   ## Assets
 
@@ -102,6 +104,7 @@ defmodule Kino.Output do
   """
   @type js_info :: %{
           ref: js_output_ref(),
+          pid: Process.dest(),
           assets: %{
             archive_path: String.t(),
             hash: String.t(),
@@ -322,11 +325,11 @@ defmodule Kino.Output do
   end
 
   @doc """
-  See `t:js_dynamic/0`.
+  See `t:js/0`.
   """
-  @spec js_dynamic(js_info(), Process.dest()) :: t()
-  def js_dynamic(info, pid) when is_map(info) do
-    {:js_dynamic, info, pid}
+  @spec js(js_info()) :: t()
+  def js(info) when is_map(info) do
+    {:js, info}
   end
 
   @doc """

--- a/lib/kino/output.ex
+++ b/lib/kino/output.ex
@@ -69,11 +69,11 @@ defmodule Kino.Output do
 
   And expect the following reply:
 
-      {:connect_reply, initial_data}
+      {:connect_reply, initial_data, info :: %{ref: js_output_ref()}}
 
   The server process may then keep sending one of the following events:
 
-      {:event, event :: String.t(), payload :: term()}
+      {:event, event :: String.t(), payload :: term(), info :: %{ref: js_output_ref()}}
 
   The client process may keep sending one of the following events:
 
@@ -85,6 +85,8 @@ defmodule Kino.Output do
 
   @typedoc """
   Data describing a custom JS output component.
+
+    * `:ref` - unique output identifier
 
   ## Assets
 
@@ -109,7 +111,8 @@ defmodule Kino.Output do
     * `:key` - in case the data is a map and only a specific part
       should be exported
   """
-  @type js_info() :: %{
+  @type js_info :: %{
+          ref: js_output_ref(),
           assets: %{
             archive_path: String.t(),
             hash: String.t(),
@@ -122,6 +125,8 @@ defmodule Kino.Output do
                 key: nil | term()
               }
         }
+
+  @type js_output_ref :: String.t()
 
   @typedoc """
   Animable output.

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -23,7 +23,8 @@ end
 defimpl Kino.Render, for: Kino.JS do
   def to_livebook(widget) do
     info = Kino.JS.js_info(widget)
-    Kino.Output.js_static(info, widget.data)
+    Kino.Bridge.reference_object(widget.ref, self())
+    Kino.Output.js_dynamic(info, Kino.JSDataStore.cross_node_name())
   end
 end
 

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -24,7 +24,7 @@ defimpl Kino.Render, for: Kino.JS do
   def to_livebook(widget) do
     info = Kino.JS.js_info(widget)
     Kino.Bridge.reference_object(widget.ref, self())
-    Kino.Output.js_dynamic(info, Kino.JSDataStore.cross_node_name())
+    Kino.Output.js(info)
   end
 end
 
@@ -32,7 +32,7 @@ defimpl Kino.Render, for: Kino.JS.Live do
   def to_livebook(widget) do
     Kino.Bridge.reference_object(widget.pid, self())
     info = Kino.JS.Live.js_info(widget)
-    Kino.Output.js_dynamic(info, widget.pid)
+    Kino.Output.js(info)
   end
 end
 

--- a/test/kino/data_table_test.exs
+++ b/test/kino/data_table_test.exs
@@ -277,12 +277,12 @@ defmodule Kino.DataTableTest do
                       page: 2,
                       max_page: 3,
                       rows: [%{fields: %{"0" => "11"}} | _]
-                    }}
+                    }, %{}}
   end
 
   defp connect_self(widget) do
     send(widget.pid, {:connect, self(), %{origin: self()}})
-    assert_receive {:connect_reply, %{} = data}
+    assert_receive {:connect_reply, %{} = data, %{}}
     data
   end
 end

--- a/test/kino/ecto_test.exs
+++ b/test/kino/ecto_test.exs
@@ -291,7 +291,7 @@ defmodule Kino.EctoTest do
   end
 
   defp await_connect_self() do
-    assert_receive {:connect_reply, %{} = data}
+    assert_receive {:connect_reply, %{} = data, %{}}
     data
   end
 

--- a/test/kino/ets_test.exs
+++ b/test/kino/ets_test.exs
@@ -122,12 +122,12 @@ defmodule Kino.ETSTest do
                       page: 2,
                       max_page: 3,
                       rows: [%{fields: %{"0" => "11"}} | _]
-                    }}
+                    }, %{}}
   end
 
   defp connect_self(widget) do
     send(widget.pid, {:connect, self(), %{origin: self()}})
-    assert_receive {:connect_reply, %{} = data}
+    assert_receive {:connect_reply, %{} = data, %{}}
     data
   end
 end

--- a/test/kino/js/live_test.exs
+++ b/test/kino/js/live_test.exs
@@ -16,7 +16,7 @@ defmodule Kino.JS.LiveTest do
       widget = LiveCounter.new(0)
       connect_self(widget)
       LiveCounter.bump(widget, 2)
-      assert_receive {:event, "bump", %{by: 2}}
+      assert_receive {:event, "bump", %{by: 2}, %{}}
     end
 
     test "handle_call/3" do
@@ -43,7 +43,7 @@ defmodule Kino.JS.LiveTest do
 
   defp connect_self(widget) do
     send(widget.pid, {:connect, self(), %{origin: self()}})
-    assert_receive {:connect_reply, data}
+    assert_receive {:connect_reply, data, %{}}
     data
   end
 end

--- a/test/kino/js_data_store_test.exs
+++ b/test/kino/js_data_store_test.exs
@@ -1,0 +1,30 @@
+defmodule Kino.JSDataStoreTest do
+  use ExUnit.Case, async: true
+
+  test "replies to connect messages with stored data" do
+    ref = make_ref() |> inspect()
+    data = [1, 2, 3]
+    Kino.JSDataStore.store(ref, data)
+
+    send(Kino.JSDataStore, {:connect, self(), %{origin: self(), ref: ref}})
+    assert_receive {:connect_reply, ^data, %{ref: ^ref}}
+  end
+
+  test "replies to connect messages with nil when no matching data is found" do
+    ref = make_ref() |> inspect()
+
+    send(Kino.JSDataStore, {:connect, self(), %{origin: self(), ref: ref}})
+    assert_receive {:connect_reply, nil, %{ref: ^ref}}
+  end
+
+  test "{:remove, ref} removes data for the given ref" do
+    ref = make_ref() |> inspect()
+    data = [1, 2, 3]
+    Kino.JSDataStore.store(ref, data)
+
+    send(Kino.JSDataStore, {:remove, ref})
+
+    send(Kino.JSDataStore, {:connect, self(), %{origin: self(), ref: ref}})
+    assert_receive {:connect_reply, nil, %{ref: ^ref}}
+  end
+end

--- a/test/kino/vega_lite_test.exs
+++ b/test/kino/vega_lite_test.exs
@@ -26,7 +26,7 @@ defmodule Kino.VegaLiteTest do
     connect_self(widget)
 
     Kino.VegaLite.push(widget, %{x: 1, y: 1})
-    assert_receive {:event, "push", %{data: [%{x: 1, y: 1}], dataset: nil, window: nil}}
+    assert_receive {:event, "push", %{data: [%{x: 1, y: 1}], dataset: nil, window: nil}, %{}}
   end
 
   test "push/3 allows for specifying the dataset" do
@@ -35,7 +35,7 @@ defmodule Kino.VegaLiteTest do
     connect_self(widget)
 
     Kino.VegaLite.push(widget, %{x: 1, y: 1}, dataset: "points")
-    assert_receive {:event, "push", %{data: [%{x: 1, y: 1}], dataset: "points", window: nil}}
+    assert_receive {:event, "push", %{data: [%{x: 1, y: 1}], dataset: "points", window: nil}, %{}}
   end
 
   test "push/3 converts keyword list to map" do
@@ -44,7 +44,7 @@ defmodule Kino.VegaLiteTest do
     connect_self(widget)
 
     Kino.VegaLite.push(widget, x: 1, y: 1)
-    assert_receive {:event, "push", %{data: [%{x: 1, y: 1}], dataset: nil, window: nil}}
+    assert_receive {:event, "push", %{data: [%{x: 1, y: 1}], dataset: nil, window: nil}, %{}}
   end
 
   test "push/3 raises if an invalid data type is given" do
@@ -64,7 +64,7 @@ defmodule Kino.VegaLiteTest do
 
     points = [%{x: 1, y: 1}, %{x: 2, y: 2}]
     Kino.VegaLite.push_many(widget, points)
-    assert_receive {:event, "push", %{data: ^points, dataset: nil, window: nil}}
+    assert_receive {:event, "push", %{data: ^points, dataset: nil, window: nil}, %{}}
   end
 
   test "push_many/3 raises if an invalid data type is given" do
@@ -83,7 +83,7 @@ defmodule Kino.VegaLiteTest do
     connect_self(widget)
 
     Kino.VegaLite.clear(widget)
-    assert_receive {:event, "push", %{data: [], dataset: nil, window: 0}}
+    assert_receive {:event, "push", %{data: [], dataset: nil, window: 0}, %{}}
   end
 
   test "periodically/4 evaluates the given callback in background until stopped" do
@@ -100,8 +100,8 @@ defmodule Kino.VegaLiteTest do
       end
     end)
 
-    assert_receive {:event, "push", %{data: [%{x: 1, y: 1}], dataset: nil, window: nil}}
-    assert_receive {:event, "push", %{data: [%{x: 2, y: 2}], dataset: nil, window: nil}}
+    assert_receive {:event, "push", %{data: [%{x: 1, y: 1}], dataset: nil, window: nil}, %{}}
+    assert_receive {:event, "push", %{data: [%{x: 2, y: 2}], dataset: nil, window: nil}, %{}}
     refute_receive {:event, "push", _}, 5
   end
 
@@ -115,7 +115,7 @@ defmodule Kino.VegaLiteTest do
 
   defp connect_self(widget) do
     send(widget.pid, {:connect, self(), %{origin: self()}})
-    assert_receive {:connect_reply, %{} = data}
+    assert_receive {:connect_reply, %{} = data, %{}}
     data
   end
 end


### PR DESCRIPTION
Adds a reference to JS widgets and the widget messages. This way we can do multiplexing with a single subscription process in https://github.com/livebook-dev/livebook/pull/843.