### PR TITLE
Introduce broadcast communication

### DIFF
--- a/lib/kino/bridge.ex
+++ b/lib/kino/bridge.ex
@@ -93,15 +93,21 @@ defmodule Kino.Bridge do
   """
   @spec broadcast(String.t(), term()) :: :ok | {:error, request_error()}
   def broadcast(topic, message) do
-    with {:ok, reply} <- io_request({:livebook_broadcast, topic, message}), do: reply
+    with {:ok, reply} <- io_request(:livebook_get_broadcast_target),
+         {:ok, pid} <- reply do
+      send(pid, {:runtime_broadcast, topic, message})
+      :ok
+    end
   end
 
   @doc """
   Sends message to the given Livebook process.
   """
-  @spec send(pid(), term()) :: :ok | {:error, request_error()}
+  @spec send(pid(), term()) :: :ok
   def send(pid, message) do
-    with {:ok, reply} <- io_request({:livebook_send, pid, message}), do: reply
+    # For now we send directly
+    Kernel.send(pid, message)
+    :ok
   end
 
   defp io_request(request) do

--- a/lib/kino/bridge.ex
+++ b/lib/kino/bridge.ex
@@ -91,11 +91,11 @@ defmodule Kino.Bridge do
   @doc """
   Broadcasts the given message in Livebook to interested parties.
   """
-  @spec broadcast(String.t(), term()) :: :ok | {:error, request_error()}
-  def broadcast(topic, message) do
+  @spec broadcast(String.t(), String.t(), term()) :: :ok | {:error, request_error()}
+  def broadcast(topic, subtopic, message) do
     with {:ok, reply} <- io_request(:livebook_get_broadcast_target),
          {:ok, pid} <- reply do
-      send(pid, {:runtime_broadcast, topic, message})
+      send(pid, {:runtime_broadcast, topic, subtopic, message})
       :ok
     end
   end

--- a/lib/kino/bridge.ex
+++ b/lib/kino/bridge.ex
@@ -1,6 +1,8 @@
 defmodule Kino.Bridge do
   @moduledoc false
 
+  import Kernel, except: [send: 2]
+
   # This module encapsulates the communication with Livebook
   # achieved via the group leader. For the implementation of
   # that group leader see Livebook.Evaluator.IOProxy
@@ -86,11 +88,27 @@ defmodule Kino.Bridge do
     end
   end
 
+  @doc """
+  Broadcasts the given message in Livebook to interested parties.
+  """
+  @spec broadcast(String.t(), term()) :: :ok | {:error, request_error()}
+  def broadcast(topic, message) do
+    with {:ok, reply} <- io_request({:livebook_broadcast, topic, message}), do: reply
+  end
+
+  @doc """
+  Sends message to the given Livebook process.
+  """
+  @spec send(pid(), term()) :: :ok | {:error, request_error()}
+  def send(pid, message) do
+    with {:ok, reply} <- io_request({:livebook_send, pid, message}), do: reply
+  end
+
   defp io_request(request) do
     gl = Process.group_leader()
     ref = Process.monitor(gl)
 
-    send(gl, {:io_request, self(), ref, request})
+    Kernel.send(gl, {:io_request, self(), ref, request})
 
     result =
       receive do

--- a/lib/kino/js/live/context.ex
+++ b/lib/kino/js/live/context.ex
@@ -19,7 +19,7 @@ defmodule Kino.JS.Live.Context do
 
   @doc false
   def new() do
-    %__MODULE__{assigns: %{}, origin: nil, __private__: %{client_pids: []}}
+    %__MODULE__{assigns: %{}, origin: nil, __private__: %{}}
   end
 
   @doc """

--- a/lib/kino/js/live_server.ex
+++ b/lib/kino/js/live_server.ex
@@ -17,7 +17,7 @@ defmodule Kino.JS.LiveServer do
 
   def broadcast_event(ctx, event, payload) do
     ref = ctx.__private__.ref
-    Kino.Bridge.broadcast("js_live:#{ref}", {:event, event, payload, %{ref: ref}})
+    Kino.Bridge.broadcast("js_live", ref, {:event, event, payload, %{ref: ref}})
     :ok
   end
 

--- a/lib/kino/js/live_server.ex
+++ b/lib/kino/js/live_server.ex
@@ -16,10 +16,8 @@ defmodule Kino.JS.LiveServer do
   defdelegate call(pid, term, timeout), to: GenServer
 
   def broadcast_event(ctx, event, payload) do
-    for pid <- ctx.__private__.client_pids do
-      send(pid, {:event, event, payload, %{ref: ctx.__private__.ref}})
-    end
-
+    ref = ctx.__private__.ref
+    Kino.Bridge.broadcast("js_live:#{ref}", {:event, event, payload, %{ref: ref}})
     :ok
   end
 
@@ -35,7 +33,7 @@ defmodule Kino.JS.LiveServer do
         {:ok, ctx}
       end
 
-    {:ok, %{module: module, client_monitor_refs: [], ctx: ctx}}
+    {:ok, %{module: module, ctx: ctx}}
   end
 
   @impl true
@@ -52,16 +50,11 @@ defmodule Kino.JS.LiveServer do
 
   @impl true
   def handle_info({:connect, pid, %{origin: origin}}, state) do
-    ref = Process.monitor(pid)
-
-    state = update_in(state.ctx.__private__.client_pids, &[pid | &1])
-    state = update_in(state.client_monitor_refs, &[ref | &1])
-
     ctx = %{state.ctx | origin: origin}
     {:ok, data, ctx} = state.module.handle_connect(ctx)
     ctx = %{ctx | origin: nil}
 
-    send(pid, {:connect_reply, data, %{ref: state.ctx.__private__.ref}})
+    Kino.Bridge.send(pid, {:connect_reply, data, %{ref: state.ctx.__private__.ref}})
 
     {:noreply, %{state | ctx: ctx}}
   end
@@ -72,16 +65,6 @@ defmodule Kino.JS.LiveServer do
     ctx = %{ctx | origin: nil}
 
     {:noreply, %{state | ctx: ctx}}
-  end
-
-  def handle_info({:DOWN, ref, :process, pid, _reason} = msg, state) do
-    if ref in state.client_monitor_refs do
-      state = update_in(state.ctx.__private__.client_pids, &List.delete(&1, pid))
-      state = update_in(state.client_monitor_refs, &List.delete(&1, ref))
-      {:noreply, state}
-    else
-      apply_handle_info(msg, state)
-    end
   end
 
   def handle_info(msg, state) do

--- a/lib/kino/js_data_store.ex
+++ b/lib/kino/js_data_store.ex
@@ -42,7 +42,7 @@ defmodule Kino.JSDataStore do
   @impl true
   def handle_info({:connect, pid, %{origin: _origin, ref: ref}}, state) do
     data = state.ref_with_data[ref]
-    send(pid, {:connect_reply, data, %{ref: ref}})
+    Kino.Bridge.send(pid, {:connect_reply, data, %{ref: ref}})
 
     {:noreply, state}
   end

--- a/test/kino/ecto_test.exs
+++ b/test/kino/ecto_test.exs
@@ -1,6 +1,8 @@
 defmodule Kino.EctoTest do
   use ExUnit.Case, async: true
 
+  import KinoTest.JS.Live
+
   import Ecto.Query, only: [from: 2]
 
   describe "new/1" do
@@ -67,9 +69,9 @@ defmodule Kino.EctoTest do
     widget = Kino.Ecto.new(User, MockRepo)
 
     MockRepo.subscribe()
-    async_connect_self(widget)
+    async_connect(widget)
     resolve_table_queries(MockRepo, [])
-    data = await_connect_self()
+    data = await_connect(widget)
 
     assert %{
              content: %{
@@ -89,9 +91,9 @@ defmodule Kino.EctoTest do
     widget = Kino.Ecto.new(query, MockRepo)
 
     MockRepo.subscribe()
-    async_connect_self(widget)
+    async_connect(widget)
     resolve_table_queries(MockRepo, [])
-    data = await_connect_self()
+    data = await_connect(widget)
 
     assert %{
              content: %{
@@ -111,9 +113,9 @@ defmodule Kino.EctoTest do
     widget = Kino.Ecto.new(query, MockRepo)
 
     MockRepo.subscribe()
-    async_connect_self(widget)
+    async_connect(widget)
     resolve_table_queries(MockRepo, [])
-    data = await_connect_self()
+    data = await_connect(widget)
 
     assert %{content: %{columns: [], rows: []}} = data
   end
@@ -123,9 +125,9 @@ defmodule Kino.EctoTest do
     widget = Kino.Ecto.new(query, MockRepo)
 
     MockRepo.subscribe()
-    async_connect_self(widget)
+    async_connect(widget)
     resolve_table_queries(MockRepo, [])
-    data = await_connect_self()
+    data = await_connect(widget)
 
     assert %{features: [:refetch, :pagination, :sorting]} = data
   end
@@ -135,9 +137,9 @@ defmodule Kino.EctoTest do
     widget = Kino.Ecto.new(query, MockRepo)
 
     MockRepo.subscribe()
-    async_connect_self(widget)
+    async_connect(widget)
     resolve_table_queries(MockRepo, [])
-    data = await_connect_self()
+    data = await_connect(widget)
 
     assert %{features: [:refetch, :pagination]} = data
   end
@@ -167,9 +169,9 @@ defmodule Kino.EctoTest do
     ]
 
     MockRepo.subscribe()
-    async_connect_self(widget)
+    async_connect(widget)
     resolve_table_queries(MockRepo, users)
-    data = await_connect_self()
+    data = await_connect(widget)
 
     assert %{
              name: "users",
@@ -199,7 +201,7 @@ defmodule Kino.EctoTest do
     widget = Kino.Ecto.new(query, MockRepo)
 
     MockRepo.subscribe()
-    async_connect_self(widget)
+    async_connect(widget)
     %{all_query: %{offset: offset, limit: limit}} = resolve_table_queries(MockRepo, [])
 
     assert Macro.to_string(offset.expr) == "^0"
@@ -213,7 +215,7 @@ defmodule Kino.EctoTest do
     widget = Kino.Ecto.new(query, MockRepo)
 
     MockRepo.subscribe()
-    async_connect_self(widget)
+    async_connect(widget)
     %{all_query: %{order_bys: [order_by]}} = resolve_table_queries(MockRepo, [])
 
     assert Macro.to_string(order_by.expr) == "[asc: &0.name()]"
@@ -224,7 +226,7 @@ defmodule Kino.EctoTest do
     widget = Kino.Ecto.new(query, MockRepo)
 
     MockRepo.subscribe()
-    async_connect_self(widget)
+    async_connect(widget)
     resolve_table_queries(MockRepo, [])
 
     send(
@@ -244,9 +246,9 @@ defmodule Kino.EctoTest do
     results = [{1, "Amy Santiago"}, {2, "Jake Peralta"}]
 
     MockRepo.subscribe()
-    async_connect_self(widget)
+    async_connect(widget)
     resolve_table_queries(MockRepo, results)
-    data = await_connect_self()
+    data = await_connect(widget)
 
     assert %{
              content: %{
@@ -269,9 +271,9 @@ defmodule Kino.EctoTest do
     results = ["Amy Santiago", "Jake Peralta"]
 
     MockRepo.subscribe()
-    async_connect_self(widget)
+    async_connect(widget)
     resolve_table_queries(MockRepo, results)
-    data = await_connect_self()
+    data = await_connect(widget)
 
     assert %{
              content: %{
@@ -284,15 +286,6 @@ defmodule Kino.EctoTest do
                ]
              }
            } = data
-  end
-
-  defp async_connect_self(widget) do
-    send(widget.pid, {:connect, self(), %{origin: self()}})
-  end
-
-  defp await_connect_self() do
-    assert_receive {:connect_reply, %{} = data, %{}}
-    data
   end
 
   defp resolve_table_queries(repo, results) do

--- a/test/kino/ets_test.exs
+++ b/test/kino/ets_test.exs
@@ -1,5 +1,7 @@
 defmodule Kino.ETSTest do
-  use ExUnit.Case, async: true
+  use Kino.LivebookCase, async: true
+
+  import KinoTest.JS.Live
 
   describe "new/1" do
     test "raises an error when private table is given" do
@@ -28,7 +30,7 @@ defmodule Kino.ETSTest do
     tid = :ets.new(:users, [:set, :public])
 
     widget = Kino.ETS.new(tid)
-    data = connect_self(widget)
+    data = connect(widget)
 
     assert %{name: "ETS :users", features: [:refetch, :pagination]} = data
   end
@@ -37,7 +39,7 @@ defmodule Kino.ETSTest do
     tid = :ets.new(:users, [:set, :public])
 
     widget = Kino.ETS.new(tid)
-    data = connect_self(widget)
+    data = connect(widget)
 
     assert %{
              content: %{
@@ -55,7 +57,7 @@ defmodule Kino.ETSTest do
     :ets.insert(tid, {3, "Amy Santiago"})
 
     widget = Kino.ETS.new(tid)
-    data = connect_self(widget)
+    data = connect(widget)
 
     assert %{
              content: %{
@@ -85,7 +87,7 @@ defmodule Kino.ETSTest do
     :ets.insert(tid, {4})
 
     widget = Kino.ETS.new(tid)
-    data = connect_self(widget)
+    data = connect(widget)
 
     assert %{
              content: %{
@@ -105,7 +107,7 @@ defmodule Kino.ETSTest do
     for n <- 1..25, do: :ets.insert(tid, {n})
 
     widget = Kino.ETS.new(tid)
-    data = connect_self(widget)
+    data = connect(widget)
 
     assert %{
              content: %{
@@ -115,19 +117,12 @@ defmodule Kino.ETSTest do
              }
            } = data
 
-    send(widget.pid, {:event, "show_page", %{"page" => 2}, %{origin: self()}})
+    push_event(widget, "show_page", %{"page" => 2})
 
-    assert_receive {:event, "update_content",
-                    %{
-                      page: 2,
-                      max_page: 3,
-                      rows: [%{fields: %{"0" => "11"}} | _]
-                    }, %{}}
-  end
-
-  defp connect_self(widget) do
-    send(widget.pid, {:connect, self(), %{origin: self()}})
-    assert_receive {:connect_reply, %{} = data, %{}}
-    data
+    assert_broadcast_event(widget, "update_content", %{
+      page: 2,
+      max_page: 3,
+      rows: [%{fields: %{"0" => "11"}} | _]
+    })
   end
 end

--- a/test/kino/js/live_test.exs
+++ b/test/kino/js/live_test.exs
@@ -1,5 +1,7 @@
 defmodule Kino.JS.LiveTest do
-  use ExUnit.Case, async: true
+  use Kino.LivebookCase, async: true
+
+  import KinoTest.JS.Live
 
   alias Kino.TestModules.LiveCounter
 
@@ -8,15 +10,14 @@ defmodule Kino.JS.LiveTest do
     test "handle_connect/1" do
       widget = LiveCounter.new(0)
       LiveCounter.bump(widget, 1)
-      count = connect_self(widget)
+      count = connect(widget)
       assert count == 1
     end
 
     test "handle_cast/2 with event broadcast" do
       widget = LiveCounter.new(0)
-      connect_self(widget)
       LiveCounter.bump(widget, 2)
-      assert_receive {:event, "bump", %{by: 2}, %{}}
+      assert_broadcast_event(widget, "bump", %{by: 2})
     end
 
     test "handle_call/3" do
@@ -35,15 +36,9 @@ defmodule Kino.JS.LiveTest do
     test "handle_event/3" do
       widget = LiveCounter.new(0)
       # Simulate a client event
-      send(widget.pid, {:event, "bump", %{"by" => 2}, %{origin: self()}})
+      push_event(widget, "bump", %{"by" => 2})
       count = LiveCounter.read(widget)
       assert count == 2
     end
-  end
-
-  defp connect_self(widget) do
-    send(widget.pid, {:connect, self(), %{origin: self()}})
-    assert_receive {:connect_reply, data, %{}}
-    data
   end
 end

--- a/test/support/livebook_case.ex
+++ b/test/support/livebook_case.ex
@@ -2,13 +2,8 @@ defmodule Kino.LivebookCase do
   use ExUnit.CaseTemplate
 
   setup do
-    original_gl = Process.group_leader()
-
     gl = start_supervised!({KinoTest.GroupLeader, self()})
     Process.group_leader(self(), gl)
-
-    on_exit(fn ->
-      Process.group_leader(self(), original_gl)
-    end)
+    :ok
   end
 end

--- a/test/support/livebook_case.ex
+++ b/test/support/livebook_case.ex
@@ -1,0 +1,14 @@
+defmodule Kino.LivebookCase do
+  use ExUnit.CaseTemplate
+
+  setup do
+    original_gl = Process.group_leader()
+
+    gl = start_supervised!({KinoTest.GroupLeader, self()})
+    Process.group_leader(self(), gl)
+
+    on_exit(fn ->
+      Process.group_leader(self(), original_gl)
+    end)
+  end
+end

--- a/test/support/test/group_leader.ex
+++ b/test/support/test/group_leader.ex
@@ -1,0 +1,45 @@
+defmodule KinoTest.GroupLeader do
+  @moduledoc false
+
+  # A process mocking the Livebook group leader,
+  # for testing parts relying on Kino.Bridge.
+
+  use GenServer
+
+  @doc """
+  Starts a new group leader.
+
+  All messages that would be sent to Livebook are sent to
+  `target` instead.
+  """
+  def start_link(target) do
+    GenServer.start_link(__MODULE__, {target})
+  end
+
+  @impl true
+  def init({target}) do
+    {:ok, %{target: target}}
+  end
+
+  @impl true
+  def handle_info({:io_request, from, reply_as, req}, state) do
+    case io_request(req, state) do
+      :forward ->
+        send(Process.group_leader(), {:io_request, from, reply_as, req})
+
+      reply ->
+        send(from, {:io_reply, reply_as, reply})
+    end
+
+    {:noreply, state}
+  end
+
+  defp io_request(:livebook_get_broadcast_target, state) do
+    {:ok, state.target}
+  end
+
+  defp io_request(_request, _state) do
+    # Forward everything else to the default group leader
+    :forward
+  end
+end

--- a/test/support/test/js_live.ex
+++ b/test/support/test/js_live.ex
@@ -1,0 +1,76 @@
+defmodule KinoTest.JS.Live do
+  @moduledoc """
+  Conveniences for testing `Kino.JS.Live` widgets.
+  """
+
+  import ExUnit.Assertions
+
+  @doc """
+  Asserts the event will be broadcasted within `timeout`.
+
+  ## Examples
+
+      assert_broadcast_event(widget, "bump", %{by: 2})
+  """
+  defmacro assert_broadcast_event(widget, event, payload, timeout \\ 100) do
+    quote do
+      %{ref: ref} = unquote(widget)
+      topic = "js_live:#{ref}"
+
+      assert_receive {:runtime_broadcast, ^topic,
+                      {:event, unquote(event), unquote(payload), %{ref: ^ref}}},
+                     unquote(timeout)
+    end
+  end
+
+  @doc """
+  Sends a client event to the widget.
+
+  ## Examples
+
+      push_event(widget, "bump", %{"by" => 2})
+  """
+  def push_event(widget, event, payload) do
+    send(widget.pid, {:event, event, payload, %{origin: self()}})
+  end
+
+  @doc """
+  Connects to the widget and returns the initial data.
+
+  ## Examples
+
+      data = connect(widget)
+      assert data == %{count: 1}
+  """
+  def connect(widget) do
+    ref = widget.ref
+    send(widget.pid, {:connect, self(), %{ref: ref, origin: self()}})
+    assert_receive {:connect_reply, data, %{ref: ^ref}}
+    data
+  end
+
+  @doc """
+  An asynchronous version of `connect/1`, awaited with `await_connect/0`.
+
+  This is useful if you need to evaluate code between sending
+  the connect message and receiving the data.
+
+  ### Examples
+
+      async_connect(widget)
+      # ...
+      data = await_connect(widget)
+  """
+  def async_connect(widget) do
+    send(widget.pid, {:connect, self(), %{origin: self(), ref: widget.ref}})
+  end
+
+  @doc """
+  Awaits connection reply initiated by `async_connect/1/.
+  """
+  def await_connect(widget) do
+    ref = widget.ref
+    assert_receive {:connect_reply, data, %{ref: ^ref}}
+    data
+  end
+end

--- a/test/support/test/js_live.ex
+++ b/test/support/test/js_live.ex
@@ -15,9 +15,8 @@ defmodule KinoTest.JS.Live do
   defmacro assert_broadcast_event(widget, event, payload, timeout \\ 100) do
     quote do
       %{ref: ref} = unquote(widget)
-      topic = "js_live:#{ref}"
 
-      assert_receive {:runtime_broadcast, ^topic,
+      assert_receive {:runtime_broadcast, "js_live", ^ref,
                       {:event, unquote(event), unquote(payload), %{ref: ^ref}}},
                      unquote(timeout)
     end


### PR DESCRIPTION
Adds `Kino.Bridge.broadcast(topic, message)` that goes through the group leader and is later broadcasted to interested processes on Livebook side. This way we can send events from JS server to Livebook as a single message and use the pubsub there, as opposed to sending the event to individual processes in Livebook.

Also adds `Kino.Bridge.send(pid, message)`, so that all communication goes through the bridge API.