### PR TITLE
Update broadcast_event to return :ok

### DIFF
--- a/lib/kino/js/live.ex
+++ b/lib/kino/js/live.ex
@@ -43,7 +43,8 @@ defmodule Kino.JS.Live do
 
         @impl true
         def handle_cast({:replace, html}, ctx) do
-          {:noreply, ctx |> broadcast_event("replace", html) |> assign(html: html)}
+          broadcast_event(ctx, "replace", html)
+          {:noreply, assign(ctx, html: html)}
         end
 
         asset "main.js" do

--- a/lib/kino/js/live/context.ex
+++ b/lib/kino/js/live/context.ex
@@ -62,9 +62,8 @@ defmodule Kino.JS.Live.Context do
 
       broadcast_event(ctx, "new_point", %{x: 10, y: 10})
   """
-  @spec broadcast_event(t(), String.t(), term()) :: t()
+  @spec broadcast_event(t(), String.t(), term()) :: :ok
   def broadcast_event(%__MODULE__{} = ctx, event, payload \\ nil) when is_binary(event) do
     Kino.JS.LiveServer.broadcast_event(ctx, event, payload)
-    ctx
   end
 end

--- a/lib/kino/table.ex
+++ b/lib/kino/table.ex
@@ -118,8 +118,8 @@ defmodule Kino.Table do
 
   defp broadcast_update(ctx) do
     {content, ctx} = get_content(ctx)
-    ctx = assign(ctx, content: content)
     broadcast_event(ctx, "update_content", content)
+    assign(ctx, content: content)
   end
 
   defp get_content(ctx) do

--- a/lib/kino/vega_lite.ex
+++ b/lib/kino/vega_lite.ex
@@ -135,10 +135,10 @@ defmodule Kino.VegaLite do
 
   @impl true
   def handle_cast({:push, dataset, data, window}, ctx) do
+    broadcast_event(ctx, "push", %{data: data, dataset: dataset, window: window})
+
     ctx =
-      ctx
-      |> broadcast_event("push", %{data: data, dataset: dataset, window: window})
-      |> update(:datasets, fn datasets ->
+      update(ctx, :datasets, fn datasets ->
         {current_data, datasets} = Map.pop(datasets, dataset, [])
 
         new_data =
@@ -155,11 +155,8 @@ defmodule Kino.VegaLite do
   end
 
   def handle_cast({:clear, dataset}, ctx) do
-    ctx =
-      ctx
-      |> broadcast_event("push", %{data: [], dataset: dataset, window: 0})
-      |> update(:datasets, &Map.delete(&1, dataset))
-
+    broadcast_event(ctx, "push", %{data: [], dataset: dataset, window: 0})
+    ctx = update(ctx, :datasets, &Map.delete(&1, dataset))
     {:noreply, ctx}
   end
 

--- a/test/support/test_modules/live_counter.ex
+++ b/test/support/test_modules/live_counter.ex
@@ -46,9 +46,8 @@ defmodule Kino.TestModules.LiveCounter do
   end
 
   defp bump_count(ctx, by) do
-    ctx
-    |> broadcast_event("bump", %{by: by})
-    |> update(:count, &(&1 + by))
+    broadcast_event(ctx, "bump", %{by: by})
+    update(ctx, :count, &(&1 + by))
   end
 
   asset "main.js" do


### PR DESCRIPTION
We are now sending the event directly, so there's no reason to return `ctx` from `broadcast_event`, as this gives false idea that it changes the context.