### PR TITLE
Hide Vega-Lite actions not compatible with iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased](https://github.com/livebook-dev/kino)
+
+### Removed
+
+* Removed Vega-Lite plot actions incompatible with Livebook ([#83](https://github.com/livebook-dev/kino/pull/83))
+
+### Fixed
+
+* Fixed `Kino.JS` to recompile modules when assets change ([#83](https://github.com/livebook-dev/kino/pull/83))
+
 ## [v0.5.1](https://github.com/livebook-dev/kino/tree/v0.5.1) (2022-01-25)
 
 ### Fixed

--- a/lib/assets/vega_lite/main.js
+++ b/lib/assets/vega_lite/main.js
@@ -14,7 +14,11 @@ export function init(ctx, data) {
     spec.data = { values: [] };
   }
 
-  vegaEmbed(ctx.root, spec, {})
+  const options = {
+    actions: { export: true, source: false, compiled: false, editor: false },
+  };
+
+  vegaEmbed(ctx.root, spec, options)
     .then((result) => {
       const view = result.view;
 

--- a/lib/kino/js.ex
+++ b/lib/kino/js.ex
@@ -203,7 +203,7 @@ defmodule Kino.JS do
     loaded_assets =
       for path <- asset_paths do
         abs_path = Path.join(assets_path, path)
-        Module.put_attribute(env.module, :external_resources, Path.relative_to_cwd(abs_path))
+        Module.put_attribute(env.module, :external_resource, Path.relative_to_cwd(abs_path))
         content = File.read!(abs_path)
         {path, content}
       end


### PR DESCRIPTION
Options other than export are not particularly useful and they don't work inside iframe, so we should hide them.