### PR TITLE
Show more table metadata

### DIFF
--- a/lib/assets/data_table/main.css
+++ b/lib/assets/data_table/main.css
@@ -124,11 +124,27 @@
 
 .table__cell-content {
   display: flex;
+  flex-direction: column;
+}
+
+.table__cell-content-primary {
+  display: flex;
   align-items: center;
 }
 
-.table__cell-content > :not(:first-child) {
+.table__cell-content-primary > :not(:first-child) {
   margin-left: 4px;
+}
+
+.table__cell-content-primary {
+  display: flex;
+  align-items: center;
+}
+
+.table__cell-content-secondary {
+  margin-top: 2px;
+  font-size: 0.875rem;
+  font-weight: 400;
 }
 
 .icon-button {

--- a/lib/assets/data_table/main.css
+++ b/lib/assets/data_table/main.css
@@ -14,7 +14,7 @@
 }
 
 .navigation {
-  margin-bottom: 16px;
+  margin-bottom: 24px;
   display: flex;
   align-items: center;
 }
@@ -23,10 +23,21 @@
   margin-left: 12px;
 }
 
+.navigation__info {
+  display: flex;
+  align-items: flex-end;
+}
+
 .navigation__name {
+  margin: 0;
   font-size: 1rem;
   font-weight: 600;
   color: var(--gray-800);
+}
+
+.navigation__details {
+  margin-left: 8px;
+  font-size: 0.875rem;
 }
 
 .navigation__space {

--- a/lib/assets/data_table/main.js
+++ b/lib/assets/data_table/main.js
@@ -9,9 +9,14 @@ export function init(ctx, data) {
     template: `
       <div class="app">
         <div class="navigation">
-          <h2 class="navigation__name">
-            {{ data.name }}
-          </h2>
+          <div class="navigation__info">
+            <h2 class="navigation__name">
+              {{ data.name }}
+            </h2>
+            <span class="navigation__details">
+              {{ data.content.total_rows }} entries
+            </span>
+          </div>
           <div class="navigation__space"></div>
           <!-- Actions -->
           <button

--- a/lib/assets/data_table/main.js
+++ b/lib/assets/data_table/main.js
@@ -73,10 +73,15 @@ export function init(ctx, data) {
                   aria-controls="table-info"
                 >
                   <div class="table__cell-content">
-                    <span>{{ column.label }}</span>
-                    <span :class="{invisible: data.content.order_by !== column.key}">
-                      <remix-icon :icon="data.content.order === 'asc' ? 'arrow-up-s-line' : 'arrow-down-s-line'"></remix-icon>
-                    </span>
+                    <div class="table__cell-content-primary">
+                      <span>{{ column.label }}</span>
+                      <span :class="{invisible: data.content.order_by !== column.key}">
+                        <remix-icon :icon="data.content.order === 'asc' ? 'arrow-up-s-line' : 'arrow-down-s-line'"></remix-icon>
+                      </span>
+                    </div>
+                    <div v-if="column.type" class="table__cell-content-secondary">
+                      {{ column.type }}
+                    </div>
                   </div>
                 </th>
               </tr>
@@ -129,7 +134,7 @@ export function init(ctx, data) {
       orderDescription() {
         const key = this.data.content.order_by;
         const { label } = this.data.content.columns.find((column) => column.key === key);
-        const order =  this.data.content.order === "asc" ? "ascending" : "descending";
+        const order = this.data.content.order === "asc" ? "ascending" : "descending";
         return `ordered by ${label}, ${order}`;
       },
     },

--- a/lib/kino/table.ex
+++ b/lib/kino/table.ex
@@ -14,13 +14,14 @@ defmodule Kino.Table do
         }
 
   @type column :: %{
-          key: term(),
-          label: binary()
+          :key => term(),
+          :label => String.t(),
+          optional(:type) => String.t()
         }
 
   @type row :: %{
           # A string value for every column key
-          fields: list(%{term() => binary()})
+          fields: list(%{term() => String.t()})
         }
 
   @type state :: term()

--- a/lib/kino/table.ex
+++ b/lib/kino/table.ex
@@ -143,6 +143,7 @@ defmodule Kino.Table do
       columns: columns,
       page: ctx.assigns.page,
       max_page: ceil(total_rows / ctx.assigns.limit),
+      total_rows: total_rows,
       order: ctx.assigns.order,
       order_by: key_to_string[ctx.assigns.order_by]
     }


### PR DESCRIPTION
I want to rebase #42, it should be much simpler with the abstractions we now have. This PR extracts some generic changes, specifically we now show the total number of entries and also support optional type information on columns (this we don't currently use, but it's a simple addition and useful moving forward).

![image](https://user-images.githubusercontent.com/17034772/153029001-c3bfd7eb-dc7e-4e56-ba0a-6fcaa13422ea.png)

*Note that the types above are just a showcase, we don't show these for `DataTable`.*