### PR TITLE
Renders ETS as tuples

### DIFF
--- a/lib/kino/ets.ex
+++ b/lib/kino/ets.ex
@@ -12,8 +12,6 @@ defmodule Kino.ETS do
 
   @behaviour Kino.Table
 
-  alias Kino.Utils
-
   @type t :: Kino.JS.Live.t()
 
   @doc """
@@ -51,9 +49,9 @@ defmodule Kino.ETS do
   @impl true
   def get_data(rows_spec, state) do
     records = get_records(state.tid, rows_spec)
-    rows = Enum.map(records, &record_to_row/1)
+    rows = Enum.map(records, fn record -> %{fields: %{0 => inspect(record)}} end)
     total_rows = :ets.info(state.tid, :size)
-    columns = records |> Utils.Table.keys_for_records() |> Utils.Table.keys_to_columns()
+    columns = if records == [], do: [], else: [%{key: 0, label: "rows"}]
     {:ok, %{columns: columns, rows: rows, total_rows: total_rows}, state}
   end
 
@@ -68,15 +66,5 @@ defmodule Kino.ETS do
     records = :qlc.next_answers(cursor, rows_spec.limit)
     :qlc.delete_cursor(cursor)
     records
-  end
-
-  defp record_to_row(record) do
-    fields =
-      record
-      |> Tuple.to_list()
-      |> Enum.with_index()
-      |> Map.new(fn {val, idx} -> {idx, inspect(val)} end)
-
-    %{fields: fields}
   end
 end

--- a/test/kino/ets_test.exs
+++ b/test/kino/ets_test.exs
@@ -62,13 +62,12 @@ defmodule Kino.ETSTest do
     assert %{
              content: %{
                columns: [
-                 %{key: "0", label: "0"},
-                 %{key: "1", label: "1"}
+                 %{key: "0", label: "rows"}
                ],
                rows: [
-                 %{fields: %{"0" => "1", "1" => ~s/"Jake Peralta"/}},
-                 %{fields: %{"0" => "2", "1" => ~s/"Terry Jeffords"/}},
-                 %{fields: %{"0" => "3", "1" => ~s/"Amy Santiago"/}}
+                 %{fields: %{"0" => "{1, \"Jake Peralta\"}"}},
+                 %{fields: %{"0" => "{2, \"Terry Jeffords\"}"}},
+                 %{fields: %{"0" => "{3, \"Amy Santiago\"}"}}
                ],
                page: 1,
                max_page: 1,
@@ -92,10 +91,7 @@ defmodule Kino.ETSTest do
     assert %{
              content: %{
                columns: [
-                 %{key: "0", label: "0"},
-                 %{key: "1", label: "1"},
-                 %{key: "2", label: "2"},
-                 %{key: "3", label: "3"}
+                 %{key: "0", label: "rows"}
                ]
              }
            } = data
@@ -113,7 +109,7 @@ defmodule Kino.ETSTest do
              content: %{
                page: 1,
                max_page: 3,
-               rows: [%{fields: %{"0" => "1"}} | _]
+               rows: [%{fields: %{"0" => "{1}"}} | _]
              }
            } = data
 
@@ -122,7 +118,7 @@ defmodule Kino.ETSTest do
     assert_broadcast_event(widget, "update_content", %{
       page: 2,
       max_page: 3,
-      rows: [%{fields: %{"0" => "11"}} | _]
+      rows: [%{fields: %{"0" => "{11}"}} | _]
     })
   end
 end


### PR DESCRIPTION
This PR changes the way we show ETS tables. Now we always have only one column named `rows` and all rows are just tuples.

<img width="899" alt="Screen Shot 2022-02-08 at 00 55 13" src="https://user-images.githubusercontent.com/5660941/153055829-ec49a158-aa6c-4cbe-a61d-8416abf70322.png">
