### PR TITLE
Use monospace font in tables

### DIFF
--- a/lib/assets/data_table/main.css
+++ b/lib/assets/data_table/main.css
@@ -1,6 +1,9 @@
-.app {
-  font-family: "Inter";
+html {
+  font-size: 87.5%;
+}
 
+.app {
+  font-family: "JetBrains Mono", monospace;
   padding: 0px 12px 12px 12px;
 
   --gray-50: #f8fafc;
@@ -31,6 +34,7 @@
 .navigation__name {
   margin: 0;
   font-size: 1rem;
+  line-height: 1;
   font-weight: 600;
   color: var(--gray-800);
 }
@@ -38,6 +42,7 @@
 .navigation__details {
   margin-left: 8px;
   font-size: 0.875rem;
+  line-height: 1;
 }
 
 .navigation__space {
@@ -78,7 +83,7 @@
 }
 
 .pagination__info {
-  padding: 6px 12px;
+  padding: 4px 8px;
   border: 1px solid var(--gray-400);
   font-size: 0.875rem;
   font-weight: 500;
@@ -126,7 +131,7 @@
 
 .table__head .table__cell {
   color: var(--gray-700);
-  font-width: 600;
+  font-weight: 600;
 }
 
 .table__cell--clickable {
@@ -196,7 +201,7 @@
 .ri {
   font-size: 1.25rem;
   vertical-align: middle;
-  line-size: 1;
+  line-height: 1;
 }
 
 .tiny-scrollbar::-webkit-scrollbar {

--- a/lib/assets/data_table/main.js
+++ b/lib/assets/data_table/main.js
@@ -2,7 +2,7 @@ import * as Vue from "https://cdn.jsdelivr.net/npm/vue@3.2.26/dist/vue.esm-brows
 
 export function init(ctx, data) {
   ctx.importCSS("main.css");
-  ctx.importCSS("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap");
+  ctx.importCSS("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap");
   ctx.importCSS("https://cdn.jsdelivr.net/npm/remixicon@2.5.0/fonts/remixicon.min.css");
 
   const app = Vue.createApp({


### PR DESCRIPTION
I made the navigation bar also use monospaced font for consistency, and so that we don't need to load another font just for that.

![image](https://user-images.githubusercontent.com/17034772/153070191-7abab36b-3024-48b2-876f-6ec1fd6c36d9.png)

![image](https://user-images.githubusercontent.com/17034772/153070217-45d2facf-9985-4f19-84c2-a60e35d77c56.png)