### PR TITLE
Add example for styling a Kino HTML widget

### DIFF
--- a/lib/kino/js.ex
+++ b/lib/kino/js.ex
@@ -63,11 +63,9 @@ defmodule Kino.JS do
   ### Stylesheets
 
   The `ctx.importCSS(url)` function allows us to load CSS from the given
-  URL into the page. The stylesheet can be from an external URL or
-  defined through the `asset/2` macro.
-
-  Here's how we would define a widget that loads and applies a google font,
-  to the body of the embedded html.
+  URL into the page. The stylesheet can be an external resource, such as
+  a font from Google Fonts or a custom asset (as outlined above). Here's
+  an example of both:
 
       defmodule Kino.HTML do
         use Kino.JS
@@ -81,6 +79,7 @@ defmodule Kino.JS do
           export function init(ctx, html) {
             ctx.importCSS("https://fonts.googleapis.com/css?family=Sofia")
             ctx.importCSS("main.css")
+
             ctx.root.innerHTML = html;
           }
           """

--- a/lib/kino/js.ex
+++ b/lib/kino/js.ex
@@ -60,6 +60,41 @@ defmodule Kino.JS do
 
       use Kino.JS, assets_path: "lib/assets/html"
 
+  ### Stylesheets
+
+  The `ctx.importCSS(url)` function allows us to load CSS from the given
+  URL into the page. The stylesheet can be from an external URL or
+  defined through the `asset/2` macro.
+
+  Here's how we would define a widget that loads and applies a google font,
+  to the body of the embedded html.
+
+      defmodule Kino.HTML do
+        use Kino.JS
+
+        def new(html) do
+          Kino.JS.new(__MODULE__, html)
+        end
+
+        asset "main.js" do
+          """
+          export function init(ctx, html) {
+            ctx.importCSS("https://fonts.googleapis.com/css?family=Sofia")
+            ctx.importCSS("main.css")
+            ctx.root.innerHTML = html;
+          }
+          """
+        end
+
+        asset "main.css" do
+          """
+          body {
+            font-family: "Sofia", sans-serif;
+          }
+          """
+        end
+      end
+
   ### URLs
 
   When using multiple asset files, make sure to use relative URLs.


### PR DESCRIPTION
First PR! feedback appreciated :)

Inspired by https://github.com/livebook-dev/kino/issues/96

After struggling to understand how to apply CSS to custom widgets, I've added an example that imports a `main.css` file and a random font from google fonts.

Hopefully, this should give people a better idea of how to apply CSS to their own widgets.