### PR TITLE
Custom table names

### DIFF
--- a/lib/kino/data_table.ex
+++ b/lib/kino/data_table.ex
@@ -39,6 +39,8 @@ defmodule Kino.DataTable do
     * `:keys` - a list of keys to include in the table for each record.
       The order is reflected in the rendered table. Optional.
 
+    * `:name` - The displayed name of the table. Defaults to `"Data"`.
+
     * `:sorting_enabled` - whether the widget should support sorting the data.
       Sorting requires traversal of the whole enumerable, so it may not be
       desirable for lazy enumerables. Defaults to `true` if data is a list

--- a/lib/kino/data_table.ex
+++ b/lib/kino/data_table.ex
@@ -52,9 +52,9 @@ defmodule Kino.DataTable do
     validate_data!(data)
 
     keys = opts[:keys]
+    name = Keyword.get(opts, :name, "Data")
     sorting_enabled = Keyword.get(opts, :sorting_enabled, is_list(data))
     show_underscored = Keyword.get(opts, :show_underscored, false)
-    name = Keyword.get(opts, :name, "Data")
 
     opts = %{
       data: data,

--- a/lib/kino/data_table.ex
+++ b/lib/kino/data_table.ex
@@ -54,10 +54,12 @@ defmodule Kino.DataTable do
     keys = opts[:keys]
     sorting_enabled = Keyword.get(opts, :sorting_enabled, is_list(data))
     show_underscored = Keyword.get(opts, :show_underscored, false)
+    name = Keyword.get(opts, :name, "Data")
 
     opts = %{
       data: data,
       keys: keys,
+      name: name,
       sorting_enabled: sorting_enabled,
       show_underscored: show_underscored
     }
@@ -102,12 +104,13 @@ defmodule Kino.DataTable do
     %{
       data: data,
       keys: keys,
+      name: name,
       sorting_enabled: sorting_enabled,
       show_underscored: show_underscored
     } = opts
 
     features = Kino.Utils.truthy_keys(pagination: true, sorting: sorting_enabled)
-    info = %{name: "Data", features: features}
+    info = %{name: name, features: features}
     total_rows = Enum.count(data)
 
     {:ok, info,

--- a/test/kino/data_table_test.exs
+++ b/test/kino/data_table_test.exs
@@ -255,4 +255,16 @@ defmodule Kino.DataTableTest do
       rows: [%{fields: %{"0" => "11"}} | _]
     })
   end
+
+  test "default table name is Data" do
+    widget = Kino.DataTable.new([])
+    data = connect(widget)
+    assert %{name: "Data"} = data
+  end
+
+  test "supports setting table name" do
+    widget = Kino.DataTable.new([], name: "Example")
+    data = connect(widget)
+    assert %{name: "Example"} = data
+  end
 end


### PR DESCRIPTION
First non-documentation PR! Let me know if I can adjust anything :) 

This PR allows `DataTable` to accept a `:name` option.

![image](https://user-images.githubusercontent.com/14877564/157747277-30bec1ac-8b0d-4d34-9fd6-69d89f08d5da.png)

I would find this feature very useful if there's an interest in accepting it. Open to any feedback or suggested changes.