### PR TITLE
Add support for string keys in DataTable

### DIFF
--- a/lib/kino/data_table.ex
+++ b/lib/kino/data_table.ex
@@ -3,7 +3,7 @@ defmodule Kino.DataTable do
   A widget for interactively viewing enumerable data.
 
   The data must be an enumerable of records, where each
-  record is either map, struct or keyword list.
+  record is either map, struct or key-value list.
 
   ## Examples
 
@@ -75,7 +75,7 @@ defmodule Kino.DataTable do
       case record_type(record) do
         :other ->
           raise ArgumentError,
-                "expected record to be either map, struct or keyword list, got: #{inspect(record)}"
+                "expected record to be either map, struct or key-value list, got: #{inspect(record)}"
 
         first_type when type == nil ->
           first_type
@@ -96,10 +96,14 @@ defmodule Kino.DataTable do
     cond do
       is_struct(record) -> :struct
       is_map(record) -> :map
-      Keyword.keyword?(record) -> :keyword_list
+      key_value_list?(record) -> :key_value_list
       true -> :other
     end
   end
+
+  def key_value_list?([{_key, _value} | rest]), do: key_value_list?(rest)
+  def key_value_list?([]), do: true
+  def key_value_list?(_other), do: false
 
   @impl true
   def init(opts) do

--- a/lib/kino/utils/table.ex
+++ b/lib/kino/utils/table.ex
@@ -84,10 +84,9 @@ defmodule Kino.Utils.Table do
   end
 
   def get_field(record, key) when is_list(record) do
-    Enum.find_value(record, fn
-      {^key, value} -> value
-      _other -> nil
-    end)
+    with {^key, value} <- List.keyfind(record, key, 0) do
+      value
+    end
   end
 
   def get_field(record, key) when is_map(record) do

--- a/lib/kino/utils/table.ex
+++ b/lib/kino/utils/table.ex
@@ -38,7 +38,7 @@ defmodule Kino.Utils.Table do
   end
 
   defp columns_for_record(record) when is_list(record) do
-    record |> Keyword.keys() |> keys_to_columns()
+    record |> Enum.map(&elem(&1, 0)) |> keys_to_columns()
   end
 
   defp columns_for_record(_record) do
@@ -84,7 +84,10 @@ defmodule Kino.Utils.Table do
   end
 
   def get_field(record, key) when is_list(record) do
-    record[key]
+    Enum.find_value(record, fn
+      {^key, value} -> value
+      _other -> nil
+    end)
   end
 
   def get_field(record, key) when is_map(record) do

--- a/test/kino/data_table_test.exs
+++ b/test/kino/data_table_test.exs
@@ -6,7 +6,7 @@ defmodule Kino.DataTableTest do
   describe "new/1" do
     test "raises an error when records have invalid data type" do
       assert_raise ArgumentError,
-                   "expected record to be either map, struct or keyword list, got: \"value\"",
+                   "expected record to be either map, struct or key-value list, got: \"value\"",
                    fn ->
                      Kino.DataTable.new(["value"])
                    end
@@ -14,7 +14,7 @@ defmodule Kino.DataTableTest do
 
     test "raises an error when records have mixed data type" do
       assert_raise ArgumentError,
-                   "expected records to have the same data type, found map and keyword_list",
+                   "expected records to have the same data type, found map and key_value_list",
                    fn ->
                      Kino.DataTable.new([%{id: 1, name: "Grumpy"}, [name: "Lil Bub"]])
                    end
@@ -97,7 +97,7 @@ defmodule Kino.DataTableTest do
            } = data
   end
 
-  test "columns preserve attributes order when records are compatible keyword lists" do
+  test "columns preserve attributes order when records are key-value lists" do
     entries = [
       [b: 1, a: 1],
       [b: 2, a: 2]
@@ -109,6 +109,22 @@ defmodule Kino.DataTableTest do
     assert %{
              content: %{
                columns: [%{key: "0", label: ":b"}, %{key: "1", label: ":a"}]
+             }
+           } = data
+  end
+
+  test "supports key-value lists with string keys" do
+    entries = [
+      [{"b", 1}, {"a", 1}],
+      [{"b", 2}, {"a", 2}]
+    ]
+
+    widget = Kino.DataTable.new(entries)
+    data = connect(widget)
+
+    assert %{
+             content: %{
+               columns: [%{key: "0", label: ~s/"b"/}, %{key: "1", label: ~s/"a"/}]
              }
            } = data
   end


### PR DESCRIPTION
We support keyword lists in cases where we need to preserve the order, however we want to allow any key type, as we do with maps.