### PR TITLE
Add an option to reevaluate smart cell on change

### DIFF
--- a/lib/kino/smart_cell.ex
+++ b/lib/kino/smart_cell.ex
@@ -156,6 +156,16 @@ defmodule Kino.SmartCell do
       `:top` or `:bottom`. Defaults to `:bottom`
 
     * `:default_source` - the initial editor source. Defaults to `""`
+
+  ## Other options
+
+  Other than the editor configuration, the following options are
+  supported:
+
+    * `:reevaluate_on_change` - if the cell should be reevaluated
+      whenever the generated source code changes. This option may be
+      helpful in cases where the cell output is a crucial element of
+      the UI interactions. Defaults to `false`
   '''
 
   require Logger

--- a/test/support/test/smart_cell.ex
+++ b/test/support/test/smart_cell.ex
@@ -17,7 +17,7 @@ defmodule KinoTest.SmartCell do
     quote do
       %{ref: ref} = unquote(widget)
 
-      assert_receive {:runtime_smart_cell_update, ^ref, unquote(attrs), unquote(source)},
+      assert_receive {:runtime_smart_cell_update, ^ref, unquote(attrs), unquote(source), _info},
                      unquote(timeout)
     end
   end


### PR DESCRIPTION
Adds an option for the smart cell to reevaluate when the generated source changes. Related to #106.