### PR TITLE
Ignore connections to JS data store when there is no matching data

### DIFF
--- a/lib/kino/js/data_store.ex
+++ b/lib/kino/js/data_store.ex
@@ -41,8 +41,9 @@ defmodule Kino.JS.DataStore do
 
   @impl true
   def handle_info({:connect, pid, %{origin: _origin, ref: ref}}, state) do
-    data = state.ref_with_data[ref]
-    Kino.Bridge.send(pid, {:connect_reply, data, %{ref: ref}})
+    with {:ok, data} <- Map.fetch(state.ref_with_data, ref) do
+      Kino.Bridge.send(pid, {:connect_reply, data, %{ref: ref}})
+    end
 
     {:noreply, state}
   end

--- a/test/kino/js/data_store_test.exs
+++ b/test/kino/js/data_store_test.exs
@@ -12,13 +12,6 @@ defmodule Kino.JS.DataStoreTest do
     assert_receive {:connect_reply, ^data, %{ref: ^ref}}
   end
 
-  test "replies to connect messages with nil when no matching data is found" do
-    ref = Kino.Output.random_ref()
-
-    send(DataStore, {:connect, self(), %{origin: self(), ref: ref}})
-    assert_receive {:connect_reply, nil, %{ref: ^ref}}
-  end
-
   test "{:remove, ref} removes data for the given ref" do
     ref = Kino.Output.random_ref()
     data = [1, 2, 3]
@@ -27,6 +20,6 @@ defmodule Kino.JS.DataStoreTest do
     send(DataStore, {:remove, ref})
 
     send(DataStore, {:connect, self(), %{origin: self(), ref: ref}})
-    assert_receive {:connect_reply, nil, %{ref: ^ref}}
+    refute_receive {:connect_reply, _, %{ref: ^ref}}
   end
 end


### PR DESCRIPTION
Follow up to https://github.com/livebook-dev/livebook/pull/1067. For "static" JS outputs we have a shared `JS.DataStore` server that replies to all connection requests. When data for the given output gets garbage collected, we would currently still reply with `nil`. To match the behaviour of regular server processes, we should ignore the request, as if the server terminated.