### PR TITLE
Keep initial chart builder fields enabled when the data is already available

### DIFF
--- a/lib/assets/chart_builder/main.js
+++ b/lib/assets/chart_builder/main.js
@@ -95,17 +95,22 @@ export function init(ctx, payload) {
   const typeFields = ["x_field_type", "y_field_type", "color_field_type"];
 
   const state = {
-    data_options: payload.options,
+    dataOptions: payload.data_options,
   };
 
   const selectDataElem = ctx.root.querySelector(`[name="data_variable"]`);
   const selectColorFieldElem = ctx.root.querySelector(`[name="color_field"]`);
 
   updateInfoBox(payload.missing_dep);
-  payload.fresh ? setFreshData(payload.options) : renderCurrentData(payload.fields);
+
+  if (payload.fresh) {
+    setFreshData(payload.data_options);
+  } else {
+    renderCurrentData(payload.fields, payload.data_options);
+  }
 
   ctx.root.addEventListener("change", handleFieldChange);
-  selectDataElem.addEventListener("change", updateDataOptions);
+  selectDataElem.addEventListener("change", updateAxisOptions);
   selectColorFieldElem.addEventListener("change", maybeResetColorType);
 
   function handleFieldChange(event) {
@@ -113,10 +118,10 @@ export function init(ctx, payload) {
     ctx.pushEvent("update_field", { field: name, value });
   }
 
-  function updateDataOptions(event) {
+  function updateAxisOptions(event) {
     const { value } = event.target;
-    const options = state.data_options[value];
-    setAxisOptions(options);
+    const axisOptions = state.dataOptions[value];
+    setAxisOptions(axisOptions);
   }
 
   function maybeResetColorType(event) {
@@ -134,9 +139,9 @@ export function init(ctx, payload) {
     updateInfoBox(dep);
   });
 
-  ctx.handleEvent("set_available_data", ({ options }) => {
-    state.data_options = options;
-    Object.keys(options).length ? setAvailableData(options) : updateDataInfoBox();
+  ctx.handleEvent("set_available_data", ({ data_options }) => {
+    state.dataOptions = data_options;
+    Object.keys(data_options).length ? setAvailableData(data_options) : updateDataInfoBox();
   });
 
   function setValues(fields) {
@@ -145,17 +150,17 @@ export function init(ctx, payload) {
     }
   }
 
-  function setAvailableData(options) {
+  function setAvailableData(dataOptions) {
     enableAll();
     const selectedData = selectDataElem.value;
-    if (!selectedData) { return setFreshData(options) };
-    const axisOptions = options[selectedData];
+    if (!selectedData) { return setFreshData(dataOptions) };
+    const axisOptions = dataOptions[selectedData];
     updateDataInfoBox(selectedData);
     selectDataElem.innerHTML = "";
-    createOptions(selectDataElem, Object.keys(options));
+    createOptions(selectDataElem, Object.keys(dataOptions));
     selectDataElem.value = selectedData;
     if (axisOptions) {
-      setAvailableDataOptions(axisOptions);
+      setAvailableAxisOptions(axisOptions);
       selectDataElem.classList.remove("unavailable");
     } else {
       createOptions(selectDataElem, [selectedData], "unavailable-option");
@@ -166,8 +171,12 @@ export function init(ctx, payload) {
     }
   }
 
-  function renderCurrentData(fields) {
-    disableAll();
+  function renderCurrentData(fields, dataOptions) {
+    const dataVariable = fields["data_variable"];
+    if (!dataOptions[dataVariable]) {
+      disableAll();
+    }
+
     for (const field of channelFields.concat(["data_variable"])) {
       const elem = ctx.root.querySelector(`[name="${field}"]`);
       elem.innerHTML = `<option value="${fields[field]}">${fields[field]}</option>`;
@@ -176,13 +185,13 @@ export function init(ctx, payload) {
     updateDataInfoBox(fields["data_variable"]);
   }
 
-  function setFreshData(options) {
+  function setFreshData(dataOptions) {
     enableAll();
     selectDataElem.innerHTML = "";
-    createOptions(selectDataElem, Object.keys(options));
+    createOptions(selectDataElem, Object.keys(dataOptions));
     const selected = selectDataElem.value;
-    const axisOptions = options[selected];
-    updateDataInfoBox(options[selected]);
+    const axisOptions = dataOptions[selected];
+    updateDataInfoBox(dataOptions[selected]);
     if (axisOptions) { setAxisOptions(axisOptions) };
     if (selected) {
       ctx.pushEvent("update_field", { field: "data_variable", value: selected });
@@ -207,13 +216,13 @@ export function init(ctx, payload) {
     }
   }
 
-  function setAvailableDataOptions(availableDataOptions) {
+  function setAvailableAxisOptions(availableAxisOptions) {
     for (const elem of channelFields) {
       const selectElem = ctx.root.querySelector(`[name="${elem}"]`);
       const selected = selectElem.value;
       const inner = elem === "color_field" ? "<option value=''></option>" : "";
       selectElem.innerHTML = inner;
-      createOptions(selectElem, availableDataOptions);
+      createOptions(selectElem, availableAxisOptions);
       selectElem.value = selected;
       if (!selectElem.value) {
         createOptions(selectElem, [selected], "unavailable-option");
@@ -277,15 +286,17 @@ export function init(ctx, payload) {
       disableAll();
       infoBox.classList.remove("hidden");
       infoBox.textContent =
-`To successfully plot graphs, you need at least one dataset available.
+        `To successfully plot graphs, you need at least one dataset available.
 
 The dataset needs to be a map of series, for exemple:
+
     my_data = %{
       a: [89, 124, 09, 67, 45],
       b: [12, 45, 67, 83, 32]
     }
 
 Or using Explorer:
+
     iris = Explorer.Datasets.iris() |> Explorer.DataFrame.to_map()`;
     }
   }

--- a/lib/kino/smart_cell/chart_builder.ex
+++ b/lib/kino/smart_cell/chart_builder.ex
@@ -24,7 +24,7 @@ defmodule Kino.SmartCell.ChartBuilder do
     ctx =
       assign(ctx,
         fields: fields,
-        options: %{},
+        data_options: %{},
         vl_alias: nil,
         missing_dep: missing_dep(),
         fresh: is_fresh?(attrs)
@@ -51,7 +51,7 @@ defmodule Kino.SmartCell.ChartBuilder do
     payload = %{
       fields: ctx.assigns.fields,
       missing_dep: ctx.assigns.missing_dep,
-      options: ctx.assigns.options,
+      data_options: ctx.assigns.data_options,
       fresh: ctx.assigns.fresh
     }
 
@@ -60,8 +60,8 @@ defmodule Kino.SmartCell.ChartBuilder do
 
   @impl true
   def handle_info({:scan_binding_result, data_options, vl_alias}, ctx) do
-    ctx = assign(ctx, options: data_options, vl_alias: vl_alias)
-    broadcast_event(ctx, "set_available_data", %{"options" => data_options})
+    ctx = assign(ctx, data_options: data_options, vl_alias: vl_alias)
+    broadcast_event(ctx, "set_available_data", %{"data_options" => data_options})
 
     {:noreply, ctx}
   end
@@ -85,7 +85,7 @@ defmodule Kino.SmartCell.ChartBuilder do
 
   defp updates_for_data_variable(ctx, value) do
     {x_field, y_field} =
-      case ctx.assigns.options[value] do
+      case ctx.assigns.data_options[value] do
         [key] -> {key, key}
         [key1, key2 | _] -> {key1, key2}
         _ -> {nil, nil}


### PR DESCRIPTION
I restarted the runtime and then evaluated everything using `Ctrl+Shift+Enter`. In such case, by the time the smart cell loads, everything is evaluated, so it receives the available data in the initial payload, so we don't want to disable the fields.