### PR TITLE
Release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.6.0](https://github.com/livebook-dev/kino/tree/v0.6.0) (2022-04-28)
+## [v0.6.1](https://github.com/livebook-dev/kino/tree/v0.6.1) (2022-05-03)
 
 This release primarily introduces `Kino.SmartCell`, which allows for
 creating custom cells in Livebook. Check out the module docs for more

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To bring Kino to Livebook all you need to do is `Mix.install/2`:
 
 ```elixir
 Mix.install([
-  {:kino, "~> 0.6.0"}
+  {:kino, "~> 0.6.1"}
 ])
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Kino.MixProject do
   use Mix.Project
 
-  @version "0.6.0"
+  @version "0.6.1"
   @description "Interactive widgets for Livebook"
 
   def project do


### PR DESCRIPTION
FTR we are going to retire 0.6.0, because it is not compatible with upcoming Livebook v0.6. Specifically, smart cells evaluation now relies on pings, so without #147 it would block.