### PR TITLE
Adjust DataTable to respect the :keys order

### DIFF
--- a/lib/kino/data_table.ex
+++ b/lib/kino/data_table.ex
@@ -50,11 +50,14 @@ defmodule Kino.DataTable do
     name = Keyword.get(opts, :name, "Data")
     sorting_enabled = Keyword.get(opts, :sorting_enabled, true)
 
-    {data_rows, %{columns: data_columns}} =
+    {data_rows, data_columns} =
       if keys = opts[:keys] do
-        Table.to_rows_with_info(tabular, only: keys)
+        {rows, %{columns: columns}} = Table.to_rows_with_info(tabular, only: keys)
+        nonexistent = keys -- columns
+        {rows, keys -- nonexistent}
       else
-        Table.to_rows_with_info(tabular)
+        {rows, %{columns: columns}} = Table.to_rows_with_info(tabular)
+        {rows, columns}
       end
 
     Kino.Table.new(__MODULE__, {data_rows, data_columns, name, sorting_enabled})

--- a/test/kino/data_table_test.exs
+++ b/test/kino/data_table_test.exs
@@ -117,6 +117,20 @@ defmodule Kino.DataTableTest do
            ]
   end
 
+  test "respects :keys order" do
+    kino = Kino.DataTable.new(@people_entries, keys: [:name, :id])
+    data = connect(kino)
+
+    assert %{
+             content: %{
+               columns: [
+                 %{key: "0", label: ":name"},
+                 %{key: "1", label: ":id"}
+               ]
+             }
+           } = data
+  end
+
   test "preserves data order by default" do
     kino = Kino.DataTable.new(@people_entries)
     data = connect(kino)


### PR DESCRIPTION
Closes #150.

Sidenote: `Table.to_rows_with_info/2` always returns all columns in `info`, but I think info is more about the table itself, rather than the specific rows. @josevalim wdyt?