### PR TITLE
Adding supervision tree visualizer

### DIFF
--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -1,0 +1,138 @@
+defmodule Kino.Process do
+  @moduledoc """
+
+  ## Examples
+  """
+
+  defmodule SupervisorGraphNode do
+    @moduledoc false
+
+    defstruct [:id, :pid, :type]
+
+    @doc false
+    def new(id, pid, type) do
+      %__MODULE__{
+        id: id,
+        pid: pid,
+        type: type
+      }
+    end
+
+    @doc false
+    def generate_node(%__MODULE__{id: id, pid: pid, type: type}) do
+      type =
+        if id == 0 do
+          :root
+        else
+          type
+        end
+
+      display =
+        pid
+        |> Process.info(:registered_name)
+        |> case do
+          {:registered_name, []} -> inspect(pid)
+          {:registered_name, name} -> inspect(name)
+        end
+
+      "#{id}(#{display}):::#{type}"
+    end
+  end
+
+  defmodule SupervisorGraphEdge do
+    @moduledoc false
+
+    defstruct [:node_1, :node_2, :relationship]
+
+    @doc false
+    def new(node_1, node_2, relationship) do
+      %__MODULE__{
+        node_1: node_1,
+        node_2: node_2,
+        relationship: relationship
+      }
+    end
+
+    @doc false
+    def generate_mermaid_entry(%__MODULE__{node_1: node_1, node_2: node_2, relationship: :link}) do
+      "#{SupervisorGraphNode.generate_node(node_1)} -..- #{SupervisorGraphNode.generate_node(node_2)}"
+    end
+
+    def generate_mermaid_entry(%__MODULE__{
+          node_1: node_1,
+          node_2: node_2,
+          relationship: :supervisor
+        }) do
+      "#{SupervisorGraphNode.generate_node(node_1)} ---> #{SupervisorGraphNode.generate_node(node_2)}"
+    end
+  end
+
+  @doc """
+  Generates a Mermaid.js graph of the supervision tree
+  """
+  @spec generate_supervision_tree(pid()) :: Kino.Markdown.t()
+  def generate_supervision_tree(supervisor) when is_pid(supervisor) do
+    initial_pid_lookup = Map.put(%{}, supervisor, 0)
+
+    {edges, _, _} =
+      supervisor
+      |> Supervisor.which_children()
+      |> traverse_processes(supervisor, {[], 1, initial_pid_lookup})
+      |> traverse_links(supervisor)
+
+    edges =
+      Enum.map_join(edges, "\n", fn edge -> SupervisorGraphEdge.generate_mermaid_entry(edge) end)
+
+    Kino.Markdown.new("""
+    ```mermaid
+    graph TD;
+    #{edges}
+    classDef root fill:#c4b5fd, stroke:#374151, stroke-width:4px;
+    classDef supervisor fill:#c4b5fd, stroke:#374151, stroke-width:1px;
+    classDef worker fill:#93c5fd, stroke:#374151, stroke-width:1px;
+    ```
+    """)
+  end
+
+  def generate_supervision_tree(invalid_pid) do
+    raise ArgumentError, "expected a PID, got: #{inspect(invalid_pid)}"
+  end
+
+  defp traverse_processes([{_, pid, :supervisor, _} | rest], supervisor, {rels, idx, pid_keys}) do
+    pid_keys = Map.put(pid_keys, pid, idx)
+    children = Supervisor.which_children(pid)
+
+    supervisor_node =
+      pid_keys
+      |> Map.get(supervisor)
+      |> SupervisorGraphNode.new(supervisor, :supervisor)
+
+    worker_node = SupervisorGraphNode.new(idx, pid, :supervisor)
+
+    new_connection = SupervisorGraphEdge.new(supervisor_node, worker_node, :supervisor)
+
+    {subtree_rels, idx, pid_keys} = traverse_processes(children, pid, {[], idx + 1, pid_keys})
+    traverse_processes(rest, supervisor, {[new_connection | subtree_rels] ++ rels, idx, pid_keys})
+  end
+
+  defp traverse_processes([{_, pid, :worker, _} | rest], supervisor, {rels, idx, pid_keys}) do
+    supervisor_node =
+      pid_keys
+      |> Map.get(supervisor)
+      |> SupervisorGraphNode.new(supervisor, :supervisor)
+
+    worker_node = SupervisorGraphNode.new(idx, pid, :worker)
+
+    new_connection = SupervisorGraphEdge.new(supervisor_node, worker_node, :supervisor)
+
+    traverse_processes(rest, supervisor, {[new_connection | rels], idx + 1, pid_keys})
+  end
+
+  defp traverse_processes([], _, acc) do
+    acc
+  end
+
+  defp traverse_links({rels, _idx, pid_keys} = thing, supervisor) do
+    thing
+  end
+end

--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -72,16 +72,20 @@ defmodule Kino.Process do
   """
   @spec generate_supervision_tree(pid()) :: Kino.Markdown.t()
   def generate_supervision_tree(supervisor) when is_pid(supervisor) do
-    initial_pid_lookup = Map.put(%{}, supervisor, 0)
+    initial_pid_lookup = Map.put(%{}, supervisor, {0, :supervisor})
 
+    # TODO: Check that the provided PID is actually a supervisor
     {edges, _, _} =
       supervisor
       |> Supervisor.which_children()
-      |> traverse_processes(supervisor, {[], 1, initial_pid_lookup})
-      |> traverse_links(supervisor)
+      |> traverse_processes(supervisor, {%{}, 1, initial_pid_lookup})
+      |> traverse_links()
 
     edges =
-      Enum.map_join(edges, "\n", fn edge -> SupervisorGraphEdge.generate_mermaid_entry(edge) end)
+      edges
+      |> Enum.map_join("\n", fn {_pid_pair, edge} ->
+        SupervisorGraphEdge.generate_mermaid_entry(edge)
+      end)
 
     Kino.Markdown.new("""
     ```mermaid
@@ -99,40 +103,77 @@ defmodule Kino.Process do
   end
 
   defp traverse_processes([{_, pid, :supervisor, _} | rest], supervisor, {rels, idx, pid_keys}) do
-    pid_keys = Map.put(pid_keys, pid, idx)
+    pid_keys = Map.put(pid_keys, pid, {idx, :supervisor})
     children = Supervisor.which_children(pid)
 
-    supervisor_node =
-      pid_keys
-      |> Map.get(supervisor)
-      |> SupervisorGraphNode.new(supervisor, :supervisor)
+    {supervisor_idx, _type} = Map.get(pid_keys, supervisor)
+    supervisor_node = SupervisorGraphNode.new(supervisor_idx, supervisor, :supervisor)
 
     worker_node = SupervisorGraphNode.new(idx, pid, :supervisor)
-
     new_connection = SupervisorGraphEdge.new(supervisor_node, worker_node, :supervisor)
 
-    {subtree_rels, idx, pid_keys} = traverse_processes(children, pid, {[], idx + 1, pid_keys})
-    traverse_processes(rest, supervisor, {[new_connection | subtree_rels] ++ rels, idx, pid_keys})
+    {subtree_rels, idx, pid_keys} = traverse_processes(children, pid, {%{}, idx + 1, pid_keys})
+
+    updated_rels =
+      rels
+      |> add_rels(subtree_rels)
+      |> add_rel(new_connection)
+
+    traverse_processes(rest, supervisor, {updated_rels, idx, pid_keys})
   end
 
   defp traverse_processes([{_, pid, :worker, _} | rest], supervisor, {rels, idx, pid_keys}) do
-    supervisor_node =
-      pid_keys
-      |> Map.get(supervisor)
-      |> SupervisorGraphNode.new(supervisor, :supervisor)
+    pid_keys = Map.put(pid_keys, pid, {idx, :worker})
+
+    {supervisor_idx, _type} = Map.get(pid_keys, supervisor)
+    supervisor_node = SupervisorGraphNode.new(supervisor_idx, supervisor, :supervisor)
 
     worker_node = SupervisorGraphNode.new(idx, pid, :worker)
-
     new_connection = SupervisorGraphEdge.new(supervisor_node, worker_node, :supervisor)
 
-    traverse_processes(rest, supervisor, {[new_connection | rels], idx + 1, pid_keys})
+    traverse_processes(rest, supervisor, {add_rel(rels, new_connection), idx + 1, pid_keys})
   end
 
   defp traverse_processes([], _, acc) do
     acc
   end
 
-  defp traverse_links({rels, _idx, pid_keys} = thing, supervisor) do
-    thing
+  defp add_rels(rels, additional_rels) do
+    Map.merge(rels, additional_rels, fn _key, edge_1, _edge_2 -> edge_1 end)
+  end
+
+  defp add_rel(rels, %SupervisorGraphEdge{} = edge) do
+    lookup = Enum.sort([edge.node_1.pid, edge.node_2.pid])
+
+    Map.put_new(rels, lookup, edge)
+  end
+
+  defp traverse_links({rels, idx, pid_keys}) do
+    rels_with_links =
+      pid_keys
+      |> Enum.reduce(rels, fn {pid, _idx}, rels_with_links ->
+        {:links, links} = Process.info(pid, :links)
+
+        links
+        |> Enum.reduce(rels_with_links, fn link, acc ->
+          add_new_links_to_acc(pid_keys, pid, link, acc)
+        end)
+      end)
+
+    {rels_with_links, idx, pid_keys}
+  end
+
+  defp add_new_links_to_acc(pid_keys, pid, link_pid, acc) do
+    with {:ok, {idx_1, type_1}} <- Map.fetch(pid_keys, pid),
+         {:ok, {idx_2, type_2}} <- Map.fetch(pid_keys, link_pid) do
+      process_1 = SupervisorGraphNode.new(idx_1, pid, type_1)
+      process_2 = SupervisorGraphNode.new(idx_2, link_pid, type_2)
+      link_edge = SupervisorGraphEdge.new(process_1, process_2, :link)
+
+      add_rel(acc, link_edge)
+    else
+      _ ->
+        acc
+    end
   end
 end

--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -155,12 +155,10 @@ defmodule Kino.Process do
 
   defp traverse_links({rels, _idx, pid_keys}) do
     rels_with_links =
-      pid_keys
-      |> Enum.reduce(rels, fn {pid, _idx}, rels_with_links ->
+      Enum.reduce(pid_keys, rels, fn {pid, _idx}, rels_with_links ->
         {:links, links} = Process.info(pid, :links)
 
-        links
-        |> Enum.reduce(rels_with_links, fn link, acc ->
+        Enum.reduce(links, rels_with_links, fn link, acc ->
           add_new_links_to_acc(pid_keys, pid, link, acc)
         end)
       end)

--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -11,8 +11,8 @@ defmodule Kino.Process do
   @doc """
   Generates a visualization of an application tree.
 
-  Given an atom denoting the name of an application, this function will render
-  the application tree. It is displayed with solid lines denoting supervisor-worker
+  Given the name of an application as an atom, this function will render the
+  application tree. It is displayed with solid lines denoting supervisor-worker
   relationships and dotted lines denoting links between processes. The graph
   rendering supports the following options:
 

--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -38,9 +38,7 @@ defmodule Kino.Process do
       Kino.Process.app_tree(:logger, direction: :left_right)
   """
   @spec app_tree(atom(), keyword()) :: Markdown.t()
-  def app_tree(application, opts \\ [])
-
-  def app_tree(application, opts) when is_atom(application) do
+  def app_tree(application, opts \\ []) when is_atom(application) do
     {master, root_supervisor} =
       case :application_controller.get_master(application) do
         :undefined ->
@@ -78,10 +76,6 @@ defmodule Kino.Process do
     classDef worker fill:#93c5fd, stroke:#374151, stroke-width:1px;
     ```
     """)
-  end
-
-  def app_tree(application, _) do
-    raise ArgumentError, "expected an atom, got: #{inspect(application)}"
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,8 @@ defmodule Kino.MixProject do
           Kino.ETS,
           Kino.Frame,
           Kino.Image,
-          Kino.Markdown
+          Kino.Markdown,
+          Kino.Process
         ],
         Inputs: [
           Kino.Input,


### PR DESCRIPTION
This PR addresses half of #154. It supports rendering supervision trees top-down and left to right. You can render the supervisor by name or by PID. The links that are displayed are only between processes within the supervision tree and process links external to the supervision tree are omitted.

I haven't added tests yet, but will add them once I know I am on the right track :smile:. Thanks in advance for the review!

Some sample images for reference:

![image](https://user-images.githubusercontent.com/4753634/175823772-0f47fc50-13b6-4492-b96f-cd6d17437647.png)
![image](https://user-images.githubusercontent.com/4753634/175823869-c73c580c-0397-4af5-a7fb-7f0f9ef5ff4f.png)
