### PR TITLE
Make data traversal lazy in Kino.DataTable

### DIFF
--- a/lib/assets/data_table/main.js
+++ b/lib/assets/data_table/main.js
@@ -14,7 +14,7 @@ export function init(ctx, data) {
               {{ data.name }}
             </h2>
             <span class="navigation__details">
-              {{ data.content.total_rows }} entries
+              {{ data.content.total_rows || "?" }} entries
             </span>
           </div>
           <div class="navigation__space"></div>
@@ -29,7 +29,7 @@ export function init(ctx, data) {
           </button>
           <!-- Pagination -->
           <div
-            v-if="data.features.includes('pagination') && data.content.rows.length > 0"
+            v-if="data.features.includes('pagination') && (data.content.total_rows === null || data.content.total_rows > 0)"
             class="pagination"
             aria-label="table pagination"
             aria-controls="table-info"
@@ -43,12 +43,12 @@ export function init(ctx, data) {
               <span>Prev</span>
             </button>
             <div class="pagination__info">
-              <span>{{ data.content.page }} of {{ data.content.max_page }}</span>
+              <span>{{ data.content.page }} of {{ data.content.max_page || "?" }}</span>
             </div>
             <button
               class="pagination__button"
               @click="next()"
-              :disabled="data.content.page === data.content.max_page"
+              :disabled="data.content.max_page && data.content.page >= data.content.max_page"
             >
               <span>Next</span>
               <remix-icon icon="arrow-right-s-line"></remix-icon>

--- a/lib/kino/data_table.ex
+++ b/lib/kino/data_table.ex
@@ -49,18 +49,19 @@ defmodule Kino.DataTable do
 
     name = Keyword.get(opts, :name, "Data")
     sorting_enabled = Keyword.get(opts, :sorting_enabled, true)
+    keys = opts[:keys]
 
-    {data_rows, data_columns} =
-      if keys = opts[:keys] do
-        {rows, %{columns: columns}} = Table.to_rows_with_info(tabular, only: keys)
-        nonexistent = keys -- columns
-        {rows, keys -- nonexistent}
+    {data_rows, data_columns, count} =
+      if keys do
+        {rows, info} = Table.to_rows_with_info(tabular, only: keys)
+        nonexistent = keys -- info.columns
+        {rows, keys -- nonexistent, info.count}
       else
-        {rows, %{columns: columns}} = Table.to_rows_with_info(tabular)
-        {rows, columns}
+        {rows, info} = Table.to_rows_with_info(tabular)
+        {rows, info.columns, info.count}
       end
 
-    Kino.Table.new(__MODULE__, {data_rows, data_columns, name, sorting_enabled})
+    Kino.Table.new(__MODULE__, {data_rows, data_columns, count, name, sorting_enabled})
   end
 
   defp normalize_tabular([%struct{} | _] = tabular) do
@@ -79,39 +80,114 @@ defmodule Kino.DataTable do
   defp normalize_tabular(tabular), do: tabular
 
   @impl true
-  def init({data_rows, data_columns, name, sorting_enabled}) do
+  def init({data_rows, data_columns, count, name, sorting_enabled}) do
     features = Kino.Utils.truthy_keys(pagination: true, sorting: sorting_enabled)
     info = %{name: name, features: features}
-    total_rows = Enum.count(data_rows)
+
+    {count, slicing_fun, slicing_cache} = init_slicing(data_rows, count)
 
     {:ok, info,
      %{
        data_rows: data_rows,
-       total_rows: total_rows,
+       total_rows: count,
+       slicing_fun: slicing_fun,
+       slicing_cache: slicing_cache,
        columns: Enum.map(data_columns, fn key -> %{key: key, label: inspect(key)} end)
      }}
   end
 
+  defp init_slicing(data_rows, count) do
+    {count, slicing_fun} =
+      case Enumerable.slice(data_rows) do
+        {:ok, count, fun} when is_function(fun, 2) -> {count, fun}
+        {:ok, count, fun} when is_function(fun, 3) -> {count, &fun.(&1, &2, 1)}
+        _ -> {count, nil}
+      end
+
+    if slicing_fun do
+      slicing_fun = fn start, length, cache ->
+        {slicing_fun.(start, length), count, cache}
+      end
+
+      {count, slicing_fun, nil}
+    else
+      cache = %{items: [], length: 0, continuation: take_init(data_rows)}
+
+      slicing_fun = fn start, length, cache ->
+        to_take = start + length - cache.length
+
+        cache =
+          if to_take > 0 and cache.continuation != nil do
+            {items, length, continuation} = take(cache.continuation, to_take)
+
+            %{
+              cache
+              | items: cache.items ++ items,
+                length: cache.length + length,
+                continuation: continuation
+            }
+          else
+            cache
+          end
+
+        count = if(cache.continuation, do: count, else: cache.length)
+
+        {Enum.slice(cache.items, start, length), count, cache}
+      end
+
+      {count, slicing_fun, cache}
+    end
+  end
+
+  defp take_init(enumerable) do
+    reducer = fn
+      x, {acc, 1} ->
+        {:suspend, {[x | acc], 0}}
+
+      x, {acc, n} when n > 1 ->
+        {:cont, {[x | acc], n - 1}}
+    end
+
+    &Enumerable.reduce(enumerable, &1, reducer)
+  end
+
+  defp take(continuation, amount) do
+    case continuation.({:cont, {[], amount}}) do
+      {:suspended, {items, 0}, continuation} ->
+        {Enum.reverse(items), amount, continuation}
+
+      {:done, {items, left}} ->
+        {Enum.reverse(items), amount - left, nil}
+    end
+  end
+
   @impl true
   def get_data(rows_spec, state) do
-    records = query(state.data_rows, rows_spec)
+    {records, count, slicing_cache} =
+      query(state.data_rows, state.slicing_fun, state.slicing_cache, rows_spec)
 
     rows =
       Enum.map(records, fn record ->
         %{fields: Map.new(record, fn {key, value} -> {key, inspect(value)} end)}
       end)
 
-    {:ok, %{columns: state.columns, rows: rows, total_rows: state.total_rows}, state}
+    total_rows = count || state.total_rows
+
+    {:ok,
+     %{
+       columns: state.columns,
+       rows: rows,
+       total_rows: total_rows
+     }, %{state | total_rows: total_rows, slicing_cache: slicing_cache}}
   end
 
-  defp query(data, rows_spec) do
-    sorted_data =
-      if order_by = rows_spec[:order_by] do
-        Enum.sort_by(data, & &1[order_by], rows_spec.order)
-      else
-        data
-      end
-
-    Enum.slice(sorted_data, rows_spec.offset, rows_spec.limit)
+  defp query(data, slicing_fun, slicing_cache, rows_spec) do
+    if order_by = rows_spec[:order_by] do
+      sorted = Enum.sort_by(data, & &1[order_by], rows_spec.order)
+      records = Enum.slice(sorted, rows_spec.offset, rows_spec.limit)
+      {records, Enum.count(sorted), slicing_cache}
+    else
+      slicing_fun.(rows_spec.offset, rows_spec.limit, slicing_cache)
+    end
   end
 end

--- a/lib/kino/table.ex
+++ b/lib/kino/table.ex
@@ -39,7 +39,7 @@ defmodule Kino.Table do
                %{
                  columns: list(column()),
                  rows: list(row()),
-                 total_rows: non_neg_integer()
+                 total_rows: non_neg_integer() | nil
                }, state()}
 
   use Kino.JS, assets_path: "lib/assets/data_table"
@@ -142,7 +142,7 @@ defmodule Kino.Table do
       rows: rows,
       columns: columns,
       page: ctx.assigns.page,
-      max_page: ceil(total_rows / ctx.assigns.limit),
+      max_page: total_rows && ceil(total_rows / ctx.assigns.limit),
       total_rows: total_rows,
       order: ctx.assigns.order,
       order_by: key_to_string[ctx.assigns.order_by]

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Kino.MixProject do
 
   defp deps do
     [
-      {:table, "~> 0.1.0"},
+      {:table, "~> 0.1.0", github: "dashbitco/table"},
       {:ex_doc, "~> 0.28", only: :dev, runtime: false}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -5,5 +5,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.16.0", "f8c570a0d33f8039513fbccaf7108c5d750f47d8defd44088371191b76492b0b", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "28b2cbdc13960a46ae9a8858c4bebdec3c9a6d7b4b9e7f4ed1502f8159f338e7"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
-  "table": {:hex, :table, "0.1.0", "f16104d717f960a623afb134a91339d40d8e11e0c96cfce54fee086b333e43f0", [:mix], [], "hexpm", "bf533d3606823ad8a7ee16f41941e5e6e0e42a20c4504cdf4cfabaaed1c8acb9"},
+  "table": {:git, "https://github.com/dashbitco/table.git", "f8621638173019a1f5e76e17e6e9362fdb25de81", []},
 }


### PR DESCRIPTION
Uses `Enumerable.slice` on row data if available, otherwise takes and caches enumerable items on demand.

This relies on some small changes to `Table`, I'm opening this for easier discussion.