### PR TITLE
Calculate count for list-backed row reader in Kino.DataTable

### DIFF
--- a/lib/kino/data_table.ex
+++ b/lib/kino/data_table.ex
@@ -96,6 +96,8 @@ defmodule Kino.DataTable do
 
   defp infer_count({:rows, _, _}, tabular) when is_list(tabular), do: length(tabular)
 
+  defp infer_count({:rows, _, enum}, _) when is_list(enum), do: length(enum)
+
   defp infer_count({:columns, _, _}, [{_, series} | _]) when is_list(series), do: length(series)
 
   defp infer_count({:columns, _, _}, %{} = tabular) do


### PR DESCRIPTION
So that we show count for all versions of Postgrex/MyXQL.