### PR TITLE
Fix Mermaid error when inspected process name starts with colon

### DIFF
--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -576,7 +576,7 @@ defmodule Kino.Process do
 
     "#{id}(#{display}):::#{type}"
   end
-  
+
   defp module_or_atom_to_string(atom) do
     case Atom.to_string(atom) do
       "Elixir." <> rest -> rest

--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -573,7 +573,7 @@ defmodule Kino.Process do
       |> Process.info(:registered_name)
       |> case do
         {:registered_name, []} -> inspect(pid)
-        {:registered_name, name} -> inspect(name)
+        {:registered_name, name} -> name |> inspect() |> String.trim_leading(":")
       end
 
     "#{id}(#{display}):::#{type}"

--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -361,7 +361,7 @@ defmodule Kino.Process do
   defp generate_participant_entry(pid, idx) do
     case Process.info(pid, :registered_name) do
       {:registered_name, name} when is_atom(name) ->
-        "participant #{idx} AS #{inspect(name)};"
+        "participant #{idx} AS #{module_or_atom_to_string(name)};"
 
       _ ->
         "participant #{idx} AS #35;PID#{:erlang.pid_to_list(pid)};"
@@ -569,13 +569,18 @@ defmodule Kino.Process do
       end
 
     display =
-      pid
-      |> Process.info(:registered_name)
-      |> case do
+      case Process.info(pid, :registered_name) do
         {:registered_name, []} -> inspect(pid)
-        {:registered_name, name} -> name |> inspect() |> String.trim_leading(":")
+        {:registered_name, name} -> module_or_atom_to_string(name)
       end
 
     "#{id}(#{display}):::#{type}"
+  end
+  
+  defp module_or_atom_to_string(atom) do
+    case Atom.to_string(atom) do
+      "Elixir." <> rest -> rest
+      rest -> rest
+    end
   end
 end


### PR DESCRIPTION
When using `Kino.Process.app_tree` when some process was registered under a name like `:"some process"`, I got a Mermaid error like this:

```
Mermaid
Parse error on line 4:
...ne):::root ---> 1(:"some process...
-----------------------^
Expecting 'SEMI', 'NEWLINE', 'SPACE', 'EOF', 'GRAPH', 'DIR', 'subgraph', 'SQS', 'SQE', 'end', 'AMP', 'DOUBLECIRCLEEND', 'PE', '-)', 'STADIUMEND', 'SUBROUTINEEND', 'ALPHA', 'COLON', 'PIPE', 'CYLINDEREND', 'DIAMOND_STOP', 'TAGEND', 'TRAPEND', 'INVTRAPEND', 'START_LINK', 'LINK', 'STYLE', 'LINKSTYLE', 'CLASSDEF', 'CLASS', 'CLICK', 'DOWN', 'UP', 'DEFAULT', 'NUM', 'COMMA', 'MINUS', 'BRKT', 'DOT', 'PCT', 'TAGSTART', 'PUNCTUATION', 'UNICODE_TEXT', 'PLUS', 'EQUALS', 'MULT', 'UNDERSCORE', got 'STR'
```

Figured out that's because of the colon at the beginning of the inspected name, so this fix removes the colon if present. Possibly there should be more proper escaping, but that worked for me ;)