### PR TITLE
Don't crash when terminating finished tasks

### DIFF
--- a/lib/kino/terminator.ex
+++ b/lib/kino/terminator.ex
@@ -25,7 +25,7 @@ defmodule Kino.Terminator do
 
   @impl true
   def handle_info({:terminate, pid}, state) do
-    :ok = DynamicSupervisor.terminate_child(Kino.DynamicSupervisor, pid)
+    DynamicSupervisor.terminate_child(Kino.DynamicSupervisor, pid)
     {:noreply, state}
   end
 end


### PR DESCRIPTION
A task started with `Kino.start_child` may be finished when the cell reevalutes, so `DynamicSupervisor.terminate_child` may be unsuccessful and that's fine.