### PR TITLE
Add send_event/4 for Kino.JS.Live

### DIFF
--- a/lib/kino/bridge.ex
+++ b/lib/kino/bridge.ex
@@ -110,6 +110,16 @@ defmodule Kino.Bridge do
     :ok
   end
 
+  @doc """
+  Starts monitoring the given Livebook process.
+
+  Provides the same semantics as `Process.monitor/1`.
+  """
+  @spec monitor(pid()) :: reference()
+  def monitor(pid) do
+    Process.monitor(pid)
+  end
+
   defp io_request(request) do
     gl = Process.group_leader()
     ref = Process.monitor(gl)

--- a/lib/kino/js/live.ex
+++ b/lib/kino/js/live.ex
@@ -253,7 +253,7 @@ defmodule Kino.JS.Live do
     quote location: :keep do
       @behaviour Kino.JS.Live
 
-      import Kino.JS.Live.Context, only: [assign: 2, update: 3, broadcast_event: 3]
+      import Kino.JS.Live.Context, only: [assign: 2, update: 3, broadcast_event: 3, send_event: 4]
 
       @before_compile Kino.JS.Live
     end

--- a/lib/kino/js/live/context.ex
+++ b/lib/kino/js/live/context.ex
@@ -53,7 +53,7 @@ defmodule Kino.JS.Live.Context do
   end
 
   @doc """
-  Sends an event to the client.
+  Sends an event to all clients.
 
   The event is dispatched to the registered JavaScript callback
   on all connected clients.
@@ -65,5 +65,20 @@ defmodule Kino.JS.Live.Context do
   @spec broadcast_event(t(), String.t(), term()) :: :ok
   def broadcast_event(%__MODULE__{} = ctx, event, payload \\ nil) when is_binary(event) do
     Kino.JS.Live.Server.broadcast_event(ctx, event, payload)
+  end
+
+  @doc """
+  Sends an event to a specific client.
+
+  The event is dispatched to the registered JavaScript callback
+  on the specific connected client.
+
+  ## Examples
+
+      send_event(ctx, origin, "new_point", %{x: 10, y: 10})
+  """
+  @spec send_event(t(), term(), String.t(), term()) :: :ok
+  def send_event(%__MODULE__{} = ctx, origin, event, payload \\ nil) when is_binary(event) do
+    Kino.JS.Live.Server.send_event(ctx, origin, event, payload)
   end
 end

--- a/lib/kino/js/live/server.ex
+++ b/lib/kino/js/live/server.ex
@@ -26,13 +26,10 @@ defmodule Kino.JS.Live.Server do
   def send_event(ctx, origin, event, payload) do
     ref = ctx.__private__.ref
 
-    pid =
-      case ctx.__private__.clients[origin] do
-        {pid, _} -> pid
-        _ -> raise "could not find a connected client with origin #{inspect(origin)}"
-      end
+    with {pid, _} <- ctx.__private__.clients[origin] do
+      Kino.Bridge.send(pid, {:event, event, payload, %{ref: ref}})
+    end
 
-    Kino.Bridge.send(pid, {:event, event, payload, %{ref: ref}})
     :ok
   end
 

--- a/lib/kino/test.ex
+++ b/lib/kino/test.ex
@@ -56,6 +56,23 @@ defmodule Kino.Test do
   end
 
   @doc """
+  Asserts a `Kino.JS.Live` kino will send an event within `timeout`
+  to the caller.
+
+  ## Examples
+
+      assert_send_event(kino, "pong", %{})
+
+  """
+  defmacro assert_send_event(kino, event, payload, timeout \\ 100) do
+    quote do
+      %{ref: ref} = unquote(kino)
+
+      assert_receive {:event, unquote(event), unquote(payload), %{ref: ^ref}}, unquote(timeout)
+    end
+  end
+
+  @doc """
   Sends a client event to a `Kino.JS.Live` kino.
 
   ## Examples

--- a/test/kino/js/live_test.exs
+++ b/test/kino/js/live_test.exs
@@ -38,6 +38,14 @@ defmodule Kino.JS.LiveTest do
       count = LiveCounter.read(kino)
       assert count == 2
     end
+
+    test "handle_event/3 with send event" do
+      kino = LiveCounter.new(0)
+      # Simulate a client event
+      _ = connect(kino)
+      push_event(kino, "ping", %{})
+      assert_send_event(kino, "pong", %{})
+    end
   end
 
   test "server ping" do

--- a/test/support/test_modules/live_counter.ex
+++ b/test/support/test_modules/live_counter.ex
@@ -29,6 +29,11 @@ defmodule Kino.TestModules.LiveCounter do
     {:noreply, bump_count(ctx, by)}
   end
 
+  def handle_event("ping", %{}, ctx) do
+    send_event(ctx, ctx.origin, "pong", %{})
+    {:noreply, ctx}
+  end
+
   @impl true
   def handle_cast({:bump, by}, ctx) do
     {:noreply, bump_count(ctx, by)}


### PR DESCRIPTION
Closes #171.

[send_event.webm](https://user-images.githubusercontent.com/17034772/182946178-99d2b0ba-01b6-47db-ae92-eab9aa4fb2c7.webm)

Note that if the same JS view is rendered multiple times, all instances are still the same client, because client.