### PR TITLE
Add default tabbed output for pids and atoms

### DIFF
--- a/lib/kino/inspect.ex
+++ b/lib/kino/inspect.ex
@@ -1,4 +1,4 @@
-defmodule Kino.Raw do
+defmodule Kino.Inspect do
   @moduledoc """
   A struct wrapping any term for default rendering.
 

--- a/lib/kino/raw.ex
+++ b/lib/kino/raw.ex
@@ -1,0 +1,19 @@
+defmodule Kino.Raw do
+  @moduledoc """
+  A struct wrapping any term for default rendering.
+
+  This is just a meta-struct that implements the `Kino.Render`
+  protocol, so that the wrapped value is rendered using the inspect
+  protocol.
+  """
+
+  defstruct [:term]
+
+  @opaque t :: %__MODULE__{term: term()}
+
+  @doc """
+  Wraps the given term.
+  """
+  @spec new(term()) :: t()
+  def new(term), do: %__MODULE__{term: term}
+end

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -18,6 +18,12 @@ defimpl Kino.Render, for: Any do
   end
 end
 
+defimpl Kino.Render, for: Kino.Raw do
+  def to_livebook(raw) do
+    Kino.Output.inspect(raw.term)
+  end
+end
+
 defimpl Kino.Render, for: Kino.JS do
   def to_livebook(kino) do
     info = Kino.JS.js_info(kino)
@@ -79,20 +85,6 @@ defimpl Kino.Render, for: Kino.Control do
 end
 
 # Elixir built-ins
-
-defmodule Kino.Raw do
-  @moduledoc false
-
-  defstruct [:term]
-
-  def new(term), do: %__MODULE__{term: term}
-
-  defimpl Kino.Render do
-    def to_livebook(raw) do
-      Kino.Output.inspect(raw.term)
-    end
-  end
-end
 
 defimpl Kino.Render, for: Reference do
   def to_livebook(reference) do

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -80,6 +80,20 @@ end
 
 # Elixir built-ins
 
+defmodule Kino.Raw do
+  @moduledoc false
+
+  defstruct [:term]
+
+  def new(term), do: %__MODULE__{term: term}
+
+  defimpl Kino.Render do
+    def to_livebook(raw) do
+      Kino.Output.inspect(raw.term)
+    end
+  end
+end
+
 defimpl Kino.Render, for: Reference do
   def to_livebook(reference) do
     cond do
@@ -101,6 +115,49 @@ defimpl Kino.Render, for: Reference do
     rescue
       # When the tid is not a valid table identifier
       ArgumentError -> false
+    end
+  end
+end
+
+defimpl Kino.Render, for: Atom do
+  def to_livebook(atom) do
+    cond do
+      application_with_supervisor?(atom) ->
+        raw = Kino.Raw.new(atom)
+        tree = Kino.Process.app_tree(atom, direction: :left_right)
+        tabs = Kino.Layout.tabs(Raw: raw, "Application tree": tree)
+        Kino.Render.to_livebook(tabs)
+
+      Kino.Utils.supervisor?(atom) ->
+        raw = Kino.Raw.new(atom)
+        tree = Kino.Process.sup_tree(atom, direction: :left_right)
+        tabs = Kino.Layout.tabs(Raw: raw, "Supervision tree": tree)
+        Kino.Render.to_livebook(tabs)
+
+      true ->
+        Kino.Output.inspect(atom)
+    end
+  end
+
+  defp application_with_supervisor?(name) do
+    with master when master != :undefined <- :application_controller.get_master(name),
+         {root, _application} when is_pid(root) <- :application_master.get_child(master),
+         do: true,
+         else: (_ -> false)
+  end
+end
+
+defimpl Kino.Render, for: PID do
+  def to_livebook(pid) do
+    cond do
+      Kino.Utils.supervisor?(pid) ->
+        raw = Kino.Raw.new(pid)
+        tree = Kino.Process.sup_tree(pid, direction: :left_right)
+        tabs = Kino.Layout.tabs(Raw: raw, "Supervision tree": tree)
+        Kino.Render.to_livebook(tabs)
+
+      true ->
+        Kino.Output.inspect(pid)
     end
   end
 end

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -18,7 +18,7 @@ defimpl Kino.Render, for: Any do
   end
 end
 
-defimpl Kino.Render, for: Kino.Raw do
+defimpl Kino.Render, for: Kino.Inspect do
   def to_livebook(raw) do
     Kino.Output.inspect(raw.term)
   end
@@ -115,13 +115,13 @@ defimpl Kino.Render, for: Atom do
   def to_livebook(atom) do
     cond do
       application_with_supervisor?(atom) ->
-        raw = Kino.Raw.new(atom)
+        raw = Kino.Inspect.new(atom)
         tree = Kino.Process.app_tree(atom, direction: :left_right)
         tabs = Kino.Layout.tabs(Raw: raw, "Application tree": tree)
         Kino.Render.to_livebook(tabs)
 
       Kino.Utils.supervisor?(atom) ->
-        raw = Kino.Raw.new(atom)
+        raw = Kino.Inspect.new(atom)
         tree = Kino.Process.sup_tree(atom, direction: :left_right)
         tabs = Kino.Layout.tabs(Raw: raw, "Supervision tree": tree)
         Kino.Render.to_livebook(tabs)
@@ -143,7 +143,7 @@ defimpl Kino.Render, for: PID do
   def to_livebook(pid) do
     cond do
       Kino.Utils.supervisor?(pid) ->
-        raw = Kino.Raw.new(pid)
+        raw = Kino.Inspect.new(pid)
         tree = Kino.Process.sup_tree(pid, direction: :left_right)
         tabs = Kino.Layout.tabs(Raw: raw, "Supervision tree": tree)
         Kino.Render.to_livebook(tabs)

--- a/lib/kino/utils.ex
+++ b/lib/kino/utils.ex
@@ -28,4 +28,16 @@ defmodule Kino.Utils do
   def has_function?(module, function, arity) do
     Code.ensure_loaded?(module) and function_exported?(module, function, arity)
   end
+
+  @doc """
+  Checks if the given process is a supervisor.
+  """
+  @spec supervisor?(atom() | pid()) :: boolean
+  def supervisor?(supervisor) do
+    with pid when is_pid(pid) <- GenServer.whereis(supervisor),
+         {:dictionary, dictionary} <- Process.info(pid, :dictionary),
+         {:supervisor, _, _} <- dictionary[:"$initial_call"],
+         do: true,
+         else: (_ -> false)
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -65,7 +65,8 @@ defmodule Kino.MixProject do
         ],
         Internal: [
           Kino.Render,
-          Kino.Output
+          Kino.Output,
+          Kino.Raw
         ],
         Testing: [
           Kino.Test

--- a/mix.exs
+++ b/mix.exs
@@ -66,7 +66,7 @@ defmodule Kino.MixProject do
         Internal: [
           Kino.Render,
           Kino.Output,
-          Kino.Raw
+          Kino.Inspect
         ],
         Testing: [
           Kino.Test


### PR DESCRIPTION
Closes #182.

[tabbed_atom_pid.webm](https://user-images.githubusercontent.com/17034772/183126271-26166836-39a3-4f27-9b2e-98692f47bb65.webm)