### PR TITLE
Add Kino.listen and expand Kino.animate

### DIFF
--- a/lib/kino/control.ex
+++ b/lib/kino/control.ex
@@ -324,56 +324,22 @@ defmodule Kino.Control do
     stream([source])
   end
 
-  @doc """
-  Consumes the given `source` (or sources) as a stream with `fun`.
-
-  The given function runs asynchronously.
-
-  See `stream/1` for more details on event sources.
-
-  ## Examples
-
-      button = Kino.Control.button("Greet")
-
-      Kino.Control.stream(button, fn _event ->
-        IO.puts("Hello!")
-      end)
-  """
-  @spec stream(event_source() | list(event_source()), (term() -> any())) :: :ok
+  # TODO: remove on Kino v0.8
+  @deprecated "Use Kino.Control.stream/1 and Kino.listen/2 instead"
   def stream(source, fun) when is_function(fun, 1) do
-    async(fn ->
-      source
-      |> stream()
-      |> Enum.each(fun)
-    end)
+    source
+    |> stream()
+    |> Kino.listen(fun)
   end
 
-  @doc ~S"""
-  A stateful version of `stream/2`.
-
-  ## Examples
-
-      button = Kino.Control.button("Greet")
-
-      Kino.Control.stream(button, 0, fn _event, counter ->
-        new_counter = counter + 1
-        IO.puts("clicks: #{new_counter}")
-        new_counter
-      end)
-  """
-  @spec stream(event_source() | list(event_source()), state, (term(), state -> state)) :: :ok
-        when state: term()
+  # TODO: remove on Kino v0.8
+  @deprecated "Use Kino.Control.stream/1 and Kino.listen/3 instead"
   def stream(source, state, fun) when is_function(fun, 2) do
-    async(fn ->
-      source
-      |> stream()
-      |> Enum.reduce(state, fun)
+    source
+    |> stream()
+    |> Kino.listen(state, fn event, state ->
+      {:cont, fun.(event, state)}
     end)
-  end
-
-  defp async(fun) do
-    Kino.start_child({Task, fun})
-    :ok
   end
 
   @doc """
@@ -408,56 +374,21 @@ defmodule Kino.Control do
     build_stream(tagged_topics, tagged_intervals, fn tag, event -> {tag, event} end)
   end
 
-  @doc """
-  Same as `stream/2`, but attaches custom tag to every event.
-
-  ## Example
-
-      button = Kino.Control.button("Hello")
-      input = Kino.Input.checkbox("Check")
-
-      Kino.Control.tagged_stream([hello: button, check: input], fn
-        {:hello, event} -> ...
-        {:check, event} -> ...
-      end)
-  """
-  @spec tagged_stream(list({tag, event_source()}), ({tag, term()} -> any())) :: :ok
-        when tag: atom()
+  # TODO: remove on Kino v0.8
+  @deprecated "Use Kino.Control.tagged_stream/1 and Kino.listen/2 instead"
   def tagged_stream(entries, fun) when is_list(entries) and is_function(fun, 1) do
-    async(fn ->
-      entries
-      |> tagged_stream()
-      |> Enum.each(fun)
-    end)
+    entries
+    |> tagged_stream()
+    |> Kino.listen(fun)
   end
 
-  @doc ~S"""
-  A stateful version of `tagged_stream/2`.
-
-  ## Example
-
-      up = Kino.Control.button("Up") |> Kino.render()
-      down = Kino.Control.button("Down") |> Kino.render()
-
-      Kino.Control.tagged_stream([up: up, down: down], 0, fn
-        {:up, _event}, counter ->
-          new_counter = counter + 1
-          IO.puts("counter: #{new_counter}")
-          new_counter
-
-        {:down, _event}, counter ->
-          new_counter = counter - 1
-          IO.puts("counter: #{new_counter}")
-          new_counter
-      end)
-  """
-  @spec tagged_stream(list({tag, event_source()}), state, ({tag, term()}, state -> state)) :: :ok
-        when tag: atom(), state: term()
+  # TODO: remove on Kino v0.8
+  @deprecated "Use Kino.Control.tagged_stream/1 and Kino.listen/3 instead"
   def tagged_stream(entries, state, fun) when is_list(entries) and is_function(fun, 2) do
-    async(fn ->
-      entries
-      |> tagged_stream()
-      |> Enum.reduce(state, fun)
+    entries
+    |> tagged_stream()
+    |> Kino.listen(state, fn event, state ->
+      {:cont, fun.(event, state)}
     end)
   end
 

--- a/test/kino/control_test.exs
+++ b/test/kino/control_test.exs
@@ -137,47 +137,6 @@ defmodule Kino.ControlTest do
     end
   end
 
-  describe "stream/2" do
-    test "runs the given function on each event" do
-      button = Kino.Control.button("Click")
-
-      myself = self()
-
-      Kino.Control.stream(button, fn event ->
-        send(myself, event)
-      end)
-
-      Process.sleep(1)
-      info = %{origin: "client1"}
-      send(button.attrs.destination, {:event, button.attrs.ref, info})
-      send(button.attrs.destination, {:event, button.attrs.ref, info})
-
-      assert_receive ^info
-      assert_receive ^info
-    end
-  end
-
-  describe "stream/3" do
-    test "reduces state over subsequent events" do
-      button = Kino.Control.button("Click")
-
-      myself = self()
-
-      Kino.Control.stream(button, 0, fn _event, counter ->
-        send(myself, {:counter, counter + 1})
-        counter + 1
-      end)
-
-      Process.sleep(1)
-      info = %{origin: "client1"}
-      send(button.attrs.destination, {:event, button.attrs.ref, info})
-      send(button.attrs.destination, {:event, button.attrs.ref, info})
-
-      assert_receive {:counter, 1}
-      assert_receive {:counter, 2}
-    end
-  end
-
   describe "tagged_stream/1" do
     test "raises on invalid argument" do
       assert_raise ArgumentError, "expected a keyword list, got: [0]", fn ->
@@ -208,58 +167,6 @@ defmodule Kino.ControlTest do
         |> Enum.take(2)
 
       assert events == [{:click, %{origin: "client1"}}, {:name, %{origin: "client1"}}]
-    end
-  end
-
-  describe "tagged_stream/2" do
-    test "runs the given function on each event" do
-      button = Kino.Control.button("Click")
-      input = Kino.Input.text("Name")
-
-      myself = self()
-
-      Kino.Control.tagged_stream([click: button, name: input], fn pair ->
-        send(myself, pair)
-      end)
-
-      Process.sleep(1)
-      info = %{origin: "client1"}
-      send(button.attrs.destination, {:event, button.attrs.ref, info})
-      send(input.attrs.destination, {:event, input.attrs.ref, info})
-
-      assert_receive {:click, ^info}
-      assert_receive {:name, ^info}
-    end
-  end
-
-  describe "tagged_stream/3" do
-    test "reduces state over subsequent events" do
-      up = Kino.Control.button("Up")
-      down = Kino.Control.button("Down")
-
-      myself = self()
-
-      Kino.Control.tagged_stream([up: up, down: down], 0, fn
-        {:up, _event}, counter ->
-          send(myself, {:counter, counter + 1})
-          counter + 1
-
-        {:down, _event}, counter ->
-          send(myself, {:counter, counter - 1})
-          counter - 1
-      end)
-
-      Process.sleep(1)
-      info = %{origin: "client1"}
-      send(up.attrs.destination, {:event, up.attrs.ref, info})
-      send(up.attrs.destination, {:event, up.attrs.ref, info})
-      send(down.attrs.destination, {:event, down.attrs.ref, info})
-      send(down.attrs.destination, {:event, down.attrs.ref, info})
-
-      assert_receive {:counter, 1}
-      assert_receive {:counter, 2}
-      assert_receive {:counter, 1}
-      assert_receive {:counter, 0}
     end
   end
 end

--- a/test/kino_test.exs
+++ b/test/kino_test.exs
@@ -1,5 +1,5 @@
 defmodule KinoTest do
-  use ExUnit.Case, async: true
+  use Kino.LivebookCase, async: true
 
   describe "inspect/2" do
     test "sends a text output to the group leader" do
@@ -32,6 +32,104 @@ defmodule KinoTest do
         )
 
       await_process(pid)
+    end
+  end
+
+  describe "animate/2" do
+    test "renders a new output for every consumed item" do
+      Stream.iterate(0, &(&1 + 1))
+      |> Stream.take(2)
+      |> Kino.animate(fn i -> i end)
+
+      assert_output({:frame, [], %{ref: ref, type: :default}})
+      assert_output({:frame, [{:text, "\e[34m0\e[0m"}], %{ref: ^ref, type: :replace}})
+      assert_output({:frame, [{:text, "\e[34m1\e[0m"}], %{ref: ^ref, type: :replace}})
+    end
+  end
+
+  describe "animate/3" do
+    test "renders a new output for every consumed item and accumulates state" do
+      Stream.iterate(0, &(&1 + 1))
+      |> Stream.take(2)
+      |> Kino.animate(0, fn i, state ->
+        {:cont, i + state, state + 1}
+      end)
+
+      assert_output({:frame, [], %{ref: ref, type: :default}})
+      assert_output({:frame, [{:text, "\e[34m0\e[0m"}], %{ref: ^ref, type: :replace}})
+      assert_output({:frame, [{:text, "\e[34m2\e[0m"}], %{ref: ^ref, type: :replace}})
+    end
+  end
+
+  describe "listen/2" do
+    test "asynchronously consumes stream items" do
+      myself = self()
+
+      Stream.iterate(0, &(&1 + 1))
+      |> Stream.take(2)
+      |> Kino.listen(fn i ->
+        send(myself, {:item, i})
+      end)
+
+      assert_receive {:item, 0}
+      assert_receive {:item, 1}
+    end
+
+    test "with control events stream" do
+      button = Kino.Control.button("Click")
+
+      myself = self()
+
+      button
+      |> Kino.Control.stream()
+      |> Kino.listen(fn event ->
+        send(myself, event)
+      end)
+
+      Process.sleep(1)
+      info = %{origin: "client1"}
+      send(button.attrs.destination, {:event, button.attrs.ref, info})
+      send(button.attrs.destination, {:event, button.attrs.ref, info})
+
+      assert_receive ^info
+      assert_receive ^info
+    end
+  end
+
+  describe "listen/3" do
+    test "asynchronously consumes stream items and accumulates state" do
+      myself = self()
+
+      Stream.iterate(0, &(&1 + 1))
+      |> Stream.take(2)
+      |> Kino.listen(0, fn i, state ->
+        send(myself, {:item, i + state})
+        {:cont, state + 1}
+      end)
+
+      assert_receive {:item, 0}
+      assert_receive {:item, 2}
+    end
+
+    test "with control events" do
+      button = Kino.Control.button("Click")
+
+      myself = self()
+
+      button
+      |> Kino.Control.stream()
+      |> Kino.listen(0, fn _event, counter ->
+        send(myself, {:counter, counter + 1})
+        {:cont, counter + 1}
+      end)
+
+      Process.sleep(1)
+      info = %{origin: "client1"}
+      send(button.attrs.destination, {:event, button.attrs.ref, info})
+      send(button.attrs.destination, {:event, button.attrs.ref, info})
+
+      assert_receive {:counter, 1}
+      assert_receive {:counter, 2}
     end
   end
 


### PR DESCRIPTION
Closes #168, closes #177.

[`Kino.listen/2,3`](https://youtu.be/RmGe-LY5HQs?t=8) replaces `Kino.Control.stream/2,3` and is more general because it accepts any stream. Similarly `Kino.animate/2` is added and `Kino.animate/3` is extended to handle streams.