### PR TITLE
Fix `Kino.Process` visualization for non-started processes

### DIFF
--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -576,7 +576,7 @@ defmodule Kino.Process do
   end
 
   defp graph_node(%{pid: :undefined, id: id, idx: idx}) do
-    "#{idx}(id:#{inspect(id)}):::notstarted"
+    "#{idx}(id: #{inspect(id)}):::notstarted"
   end
 
   defp graph_node(%{idx: idx, pid: pid, type: type}) do

--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -7,6 +7,13 @@ defmodule Kino.Process do
   alias Kino.Markdown
   alias Kino.Process.Tracer
 
+  @mermaid_classdefs """
+  classDef root fill:#c4b5fd, stroke:#374151, stroke-width:4px;
+  classDef supervisor fill:#c4b5fd, stroke:#374151, stroke-width:1px;
+  classDef worker fill:#93c5fd, stroke:#374151, stroke-width:1px;
+  classDef notstarted color:#777, fill:#d9d9d9, stroke:#777, stroke-width:1px;
+  """
+
   @type supervisor :: pid() | atom()
   @type trace_target :: :all | pid() | [pid()]
 
@@ -70,10 +77,7 @@ defmodule Kino.Process do
     application_master(#{inspect(master)}):::supervisor ---> supervisor_ancestor;
     supervisor_ancestor(#{inspect(ancestor)}):::supervisor ---> 0;
     #{edges}
-    classDef root fill:#c4b5fd, stroke:#374151, stroke-width:4px;
-    classDef supervisor fill:#c4b5fd, stroke:#374151, stroke-width:1px;
-    classDef worker fill:#93c5fd, stroke:#374151, stroke-width:1px;
-    classDef notstarted fill:#b9b9b9, stroke:#374151, stroke-width:1px;
+    #{@mermaid_classdefs}
     ```
     """)
   end
@@ -133,10 +137,7 @@ defmodule Kino.Process do
     ```mermaid
     graph #{direction};
     #{edges}
-    classDef root fill:#c4b5fd, stroke:#374151, stroke-width:4px;
-    classDef supervisor fill:#c4b5fd, stroke:#374151, stroke-width:1px;
-    classDef worker fill:#93c5fd, stroke:#374151, stroke-width:1px;
-    classDef notstarted fill:#b9b9b9, stroke:#374151, stroke-width:1px;
+    #{@mermaid_classdefs}
     ```
     """)
   end

--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -73,6 +73,7 @@ defmodule Kino.Process do
     classDef root fill:#c4b5fd, stroke:#374151, stroke-width:4px;
     classDef supervisor fill:#c4b5fd, stroke:#374151, stroke-width:1px;
     classDef worker fill:#93c5fd, stroke:#374151, stroke-width:1px;
+    classDef notstarted fill:#b9b9b9, stroke:#374151, stroke-width:1px;
     ```
     """)
   end
@@ -135,6 +136,7 @@ defmodule Kino.Process do
     classDef root fill:#c4b5fd, stroke:#374151, stroke-width:4px;
     classDef supervisor fill:#c4b5fd, stroke:#374151, stroke-width:1px;
     classDef worker fill:#93c5fd, stroke:#374151, stroke-width:1px;
+    classDef notstarted fill:#b9b9b9, stroke:#374151, stroke-width:1px;
     ```
     """)
   end
@@ -510,7 +512,11 @@ defmodule Kino.Process do
   defp traverse_links({rels, _idx, pid_keys}) do
     rels_with_links =
       Enum.reduce(pid_keys, rels, fn {pid, _idx}, rels_with_links ->
-        {:links, links} = Process.info(pid, :links)
+        {:links, links} =
+          case pid do
+            :undefined -> {:links, []}
+            pid -> Process.info(pid, :links)
+          end
 
         Enum.reduce(links, rels_with_links, fn link, acc ->
           add_new_links_to_acc(pid_keys, pid, link, acc)
@@ -558,6 +564,10 @@ defmodule Kino.Process do
 
   defp generate_mermaid_entry(%{node_1: node_1, node_2: node_2, relationship: :supervisor}) do
     "#{graph_node(node_1)} ---> #{graph_node(node_2)}"
+  end
+
+  defp graph_node(%{id: id, pid: :undefined}) do
+    "#{id}(:ignore):::notstarted"
   end
 
   defp graph_node(%{id: id, pid: pid, type: type}) do

--- a/test/kino/process_test.exs
+++ b/test/kino/process_test.exs
@@ -29,7 +29,7 @@ defmodule Kino.ProcessTest do
         Supervisor.start_link(
           [
             {Agent, fn -> :ok end},
-            %{id: :not_started, start: {__MODULE__, :start_ignore, []}}
+            %{id: :not_started, start: {Function, :identity, [:ignore]}}
           ],
           name: :supervisor_parent,
           strategy: :one_for_one
@@ -50,6 +50,4 @@ defmodule Kino.ProcessTest do
   end
 
   defp markdown(%Kino.Markdown{content: content}), do: content
-
-  def start_ignore, do: :ignore
 end

--- a/test/kino/process_test.exs
+++ b/test/kino/process_test.exs
@@ -24,6 +24,24 @@ defmodule Kino.ProcessTest do
       assert content =~ "0(supervisor_parent):::root ---> 2(#{inspect(agent)}):::worker"
     end
 
+    test "shows supervision tree with children alongside non-started children" do
+      {:ok, pid} =
+        Supervisor.start_link(
+          [
+            {Agent, fn -> :ok end},
+            %{id: :not_started, start: {__MODULE__, :start_ignore, []}}
+          ],
+          name: :supervisor_parent,
+          strategy: :one_for_one
+        )
+
+      [{:not_started, :undefined, _, _}, {_, agent, _, _}] = Supervisor.which_children(pid)
+
+      content = Kino.Process.sup_tree(pid) |> markdown()
+      assert content =~ "0(supervisor_parent):::root ---> 1(id: :not_started):::notstarted"
+      assert content =~ "0(supervisor_parent):::root ---> 2(#{inspect(agent)}):::worker"
+    end
+
     test "raises if supervisor does not exist" do
       assert_raise ArgumentError,
                    ~r/the provided identifier :not_a_valid_supervisor does not reference a running process/,
@@ -32,4 +50,6 @@ defmodule Kino.ProcessTest do
   end
 
   defp markdown(%Kino.Markdown{content: content}), do: content
+
+  def start_ignore, do: :ignore
 end


### PR DESCRIPTION
This PR fixes `Kino.Process` supervisor/app tree visualization when the tree includes processes that did not start (their `start` function returned `:ignore`). In the process, I ended up refactoring `traverse_processes/3` a bit.

Happy to answer any questions!

[Livebook demonstration](https://gist.github.com/zachallaun/aa2ce2a24660cb23341dfeeb23c51964)

Previous:
![before](https://user-images.githubusercontent.com/503938/185006536-1c4521ee-2eb2-42a2-b56f-2bf74a082d90.png)

After PR:
![after](https://user-images.githubusercontent.com/503938/185006556-9178a68f-95db-417b-8d6c-84113d82169b.png)