### PR TITLE
Add Kino.Mermaid

### DIFF
--- a/lib/kino.ex
+++ b/lib/kino.ex
@@ -42,7 +42,7 @@ defmodule Kino do
 
   ### Kino.Markdown
 
-  `Kino.Markdown` wraps Markdown content for richer text rendering.
+  `Kino.Markdown` renders Markdown content, in case you need richer text:
 
       Kino.Markdown.new("""
       # Example
@@ -61,6 +61,18 @@ defmodule Kino do
       | -- | ------ | ----------------------- |
       | 1  | Elixir | https://elixir-lang.org |
       | 2  | Erlang | https://www.erlang.org  |
+      """)
+
+  ### Kino.Mermaid
+
+  `Kino.Mermaid` renders Mermaid graphs:
+
+      Kino.Mermaid.new("""
+      graph TD;
+        A-->B;
+        A-->C;
+        B-->D;
+        C-->D;
       """)
 
   ### Kino.Frame

--- a/lib/kino/image.ex
+++ b/lib/kino/image.ex
@@ -1,6 +1,6 @@
 defmodule Kino.Image do
   @moduledoc """
-  A struct wrapping a binary image.
+  A kino for rendering a binary image.
 
   This is just a meta-struct that implements the `Kino.Render`
   protocol, so that it gets rendered as the underlying image.
@@ -24,7 +24,7 @@ defmodule Kino.Image do
   @type common_image_type :: :jpeg | :png | :gif | :svg
 
   @doc """
-  Wraps the given binary content into the image struct.
+  Creates a new kino displaying the given binary image.
 
   The given type be either `:jpeg`, `:png`, `:gif`, `:svg`
   or a string with image MIME type.

--- a/lib/kino/js.ex
+++ b/lib/kino/js.ex
@@ -150,7 +150,7 @@ defmodule Kino.JS do
   To give a concrete example, here's how we could use the `mermaid`
   JavaScript package for rendering diagrams:
 
-      defmodule Kino.Mermaid do
+      defmodule KinoDocs.Mermaid do
         use Kino.JS
 
         def new(graph) do
@@ -159,7 +159,7 @@ defmodule Kino.JS do
 
         asset "main.js" do
           """
-          import "https://cdn.jsdelivr.net/npm/mermaid@8.13.3/dist/mermaid.min.js";
+          import "https://cdn.jsdelivr.net/npm/mermaid@9.1.3/dist/mermaid.min.js";
 
           mermaid.initialize({ startOnLoad: false });
 
@@ -175,7 +175,7 @@ defmodule Kino.JS do
 
   And we would use it like so:
 
-      Kino.Mermaid.new("""
+      KinoDocs.Mermaid.new("""
       graph TD;
         A-->B;
         A-->C;

--- a/lib/kino/js/live.ex
+++ b/lib/kino/js/live.ex
@@ -141,7 +141,7 @@ defmodule Kino.JS.Live do
   The following example showcases how to send and receive events
   with binary payloads.
 
-      defmodule Kino.Binary do
+      defmodule KinoDocs.Binary do
         use Kino.JS
         use Kino.JS.Live
 

--- a/lib/kino/markdown.ex
+++ b/lib/kino/markdown.ex
@@ -1,13 +1,13 @@
 defmodule Kino.Markdown do
-  @moduledoc """
-  A struct wrapping a Markdown content.
+  @moduledoc ~S'''
+  A kino for rendering Markdown content.
 
   This is just a meta-struct that implements the `Kino.Render`
   protocol, so that it gets rendered as markdown.
 
   ## Examples
 
-      Kino.Markdown.new(\"\"\"
+      Kino.Markdown.new("""
       # Example
 
       A regular Markdown file.
@@ -24,14 +24,14 @@ defmodule Kino.Markdown do
       | -- | ------ | ----------------------- |
       | 1  | Elixir | https://elixir-lang.org |
       | 2  | Erlang | https://www.erlang.org  |
-      \"\"\")
+      """)
 
   This format may come in handy when exploring Markdown
   from external sources:
 
       content = File.read!("/path/to/README.md")
       Kino.Markdown.new(content)
-  """
+  '''
 
   @enforce_keys [:content]
 
@@ -42,7 +42,7 @@ defmodule Kino.Markdown do
           }
 
   @doc """
-  Wraps the given binary content into the markdown struct.
+  Creates a new kino displaying the given Markdown content.
   """
   @spec new(binary()) :: t()
   def new(content) do

--- a/lib/kino/mermaid.ex
+++ b/lib/kino/mermaid.ex
@@ -1,0 +1,62 @@
+defmodule Kino.Mermaid do
+  @moduledoc ~S'''
+  A kino for rendering Mermaid graphs.
+
+  > #### Relation to Kino.Markdown {: .info}
+  >
+  > Mermaid graphs can also be generated dynamically with `Kino.Markdown`,
+  > however the output of `Kino.Markdown` is never persisted in the
+  > notebook source. `Kino.Mermaid` doesn't have this limitation.
+
+  ## Examples
+
+      Kino.Mermaid.new("""
+      graph TD;
+        A-->B;
+        A-->C;
+        B-->D;
+        C-->D;
+      """)
+
+  '''
+
+  use Kino.JS
+
+  @type t :: Kino.JS.t()
+
+  @doc """
+  Creates a new kino displaying the given Mermaid graph.
+  """
+  @spec new(binary()) :: t()
+  def new(content) do
+    Kino.JS.new(__MODULE__, content, export_info_string: "mermaid")
+  end
+
+  asset "main.js" do
+    """
+    import "https://cdn.jsdelivr.net/npm/mermaid@9.1.3/dist/mermaid.min.js";
+
+    mermaid.initialize({ startOnLoad: false });
+
+    export function init(ctx, content) {
+      function render() {
+        mermaid.render("graph1", content, (svgSource, bindListeners) => {
+          ctx.root.innerHTML = svgSource;
+          bindListeners && bindListeners(ctx.root);
+
+          // A workaround for https://github.com/mermaid-js/mermaid/issues/1758
+          const svg = ctx.root.querySelector("svg");
+          svg.removeAttribute("height");
+        });
+      }
+
+      // If the JS view is not visible, defer initialization until it becomes visible
+      if (window.innerWidth === 0) {
+        window.addEventListener("resize", () => render(), { once: true });
+      } else {
+        render();
+      }
+    }
+    """
+  end
+end

--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -4,7 +4,7 @@ defmodule Kino.Process do
   introspect your running processes.
   """
 
-  alias Kino.Markdown
+  alias Kino.Mermaid
   alias Kino.Process.Tracer
 
   @mermaid_classdefs """
@@ -46,7 +46,7 @@ defmodule Kino.Process do
 
       Kino.Process.app_tree(:logger, direction: :left_right)
   """
-  @spec app_tree(atom(), keyword()) :: Markdown.t()
+  @spec app_tree(atom(), keyword()) :: Mermaid.t()
   def app_tree(application, opts \\ []) when is_atom(application) do
     {master, root_supervisor} =
       case :application_controller.get_master(application) do
@@ -75,14 +75,12 @@ defmodule Kino.Process do
     {:dictionary, dictionary} = Process.info(root_supervisor, :dictionary)
     [ancestor] = dictionary[:"$ancestors"]
 
-    Markdown.new("""
-    ```mermaid
+    Mermaid.new("""
     graph #{direction};
     application_master(#{inspect(master)}):::supervisor ---> supervisor_ancestor;
     supervisor_ancestor(#{inspect(ancestor)}):::supervisor ---> 0;
     #{edges}
     #{@mermaid_classdefs}
-    ```
     """)
   end
 
@@ -132,17 +130,15 @@ defmodule Kino.Process do
 
       Kino.Process.sup_tree(MyApp.Supervisor, direction: :left_right)
   """
-  @spec sup_tree(supervisor(), keyword()) :: Markdown.t()
+  @spec sup_tree(supervisor(), keyword()) :: Mermaid.t()
   def sup_tree(supervisor, opts \\ []) do
     direction = direction_from_opts(opts)
     edges = traverse_supervisor(supervisor)
 
-    Markdown.new("""
-    ```mermaid
+    Mermaid.new("""
     graph #{direction};
     #{edges}
     #{@mermaid_classdefs}
-    ```
     """)
   end
 
@@ -249,7 +245,7 @@ defmodule Kino.Process do
         Agent.stop(agent_pid)
       end)
   """
-  @spec seq_trace(trace_target(), (() -> any())) :: {any(), Markdown.t()}
+  @spec seq_trace(trace_target(), (() -> any())) :: {any(), Mermaid.t()}
   def seq_trace(trace_target \\ :all, trace_function)
 
   def seq_trace(pid, trace_function) when is_pid(pid) do
@@ -354,12 +350,10 @@ defmodule Kino.Process do
       |> Enum.join("\n")
 
     sequence_diagram =
-      Markdown.new("""
-      ```mermaid
+      Mermaid.new("""
       sequenceDiagram
       #{participants}
       #{messages}
-      ```
       """)
 
     {func_result, sequence_diagram}

--- a/mix.exs
+++ b/mix.exs
@@ -51,6 +51,7 @@ defmodule Kino.MixProject do
           Kino.Image,
           Kino.Layout,
           Kino.Markdown,
+          Kino.Mermaid,
           Kino.Process
         ],
         Inputs: [

--- a/test/kino/process_test.exs
+++ b/test/kino/process_test.exs
@@ -23,11 +23,11 @@ defmodule Kino.ProcessTest do
 
       [_, {_, agent, _, _}] = Supervisor.which_children(pid)
 
-      content = Kino.Process.sup_tree(pid) |> markdown()
+      content = Kino.Process.sup_tree(pid) |> mermaid()
       assert content =~ "0(supervisor_parent):::root ---> 1(agent_child):::worker"
       assert content =~ "0(supervisor_parent):::root ---> 2(#{inspect(agent)}):::worker"
 
-      content = Kino.Process.sup_tree(:supervisor_parent) |> markdown()
+      content = Kino.Process.sup_tree(:supervisor_parent) |> mermaid()
       assert content =~ "0(supervisor_parent):::root ---> 1(agent_child):::worker"
       assert content =~ "0(supervisor_parent):::root ---> 2(#{inspect(agent)}):::worker"
     end
@@ -45,7 +45,7 @@ defmodule Kino.ProcessTest do
 
       [{:not_started, :undefined, _, _}, {_, agent, _, _}] = Supervisor.which_children(pid)
 
-      content = Kino.Process.sup_tree(pid) |> markdown()
+      content = Kino.Process.sup_tree(pid) |> mermaid()
       assert content =~ "0(supervisor_parent):::root ---> 1(id: :not_started):::notstarted"
       assert content =~ "0(supervisor_parent):::root ---> 2(#{inspect(agent)}):::worker"
     end
@@ -57,5 +57,9 @@ defmodule Kino.ProcessTest do
     end
   end
 
-  defp markdown(%Kino.Markdown{content: content}), do: content
+  defp mermaid(%Kino.JS{ref: ref}) do
+    send(Kino.JS.DataStore, {:connect, self(), %{origin: "client:#{inspect(self())}", ref: ref}})
+    assert_receive {:connect_reply, data, %{ref: ^ref}}
+    data
+  end
 end


### PR DESCRIPTION
Mermaid can be useful to render dynamic representation of data structures. Currently we use `Kino.Markdown` in those cases, however markdown outputs are never persisted in the notebook source, so there's no option to render them in the docs. This adds a dedicated `Kino.Mermaid`, which can be persisted as mermaid snippet and therefor rendered in the docs.