### PR TITLE
Fix Kino.DataTable docs

### DIFF
--- a/lib/kino/data_table.ex
+++ b/lib/kino/data_table.ex
@@ -16,7 +16,10 @@ defmodule Kino.DataTable do
   The tabular view allows you to quickly preview the data
   and analyze it thanks to sorting capabilities.
 
-      data = Process.list() |> Enum.map(&Process.info/1)
+      data =
+        Process.list()
+        |> Enum.map(&Process.info/1)
+        |> Enum.map(&(Keyword.merge([registered_name: nil], &1)))
 
       Kino.DataTable.new(
         data,


### PR DESCRIPTION
The previous code failed with

    ** (RuntimeError) key-value records must have columns in the same order,
    expected :registered_name, but got :current_function

[`Process.info/1`](https://hexdocs.pm/elixir/1.12/Process.html#info/1) calls [`:process_info/1`](https://www.erlang.org/doc/man/erlang.html#process_info-1), which does not necessarily include a `:registered_name` value:

"If the process identified by Pid has a registered name, also an InfoTuple with item registered_name is included."