### PR TITLE
Add support for multi-chunk smart cell source

### DIFF
--- a/lib/kino/smart_cell.ex
+++ b/lib/kino/smart_cell.ex
@@ -208,8 +208,12 @@ defmodule Kino.SmartCell do
 
   @doc """
   Invoked to generate source code based on the given attributes.
+
+  A list of sources can be returned, in which case the sources are
+  joined into a single source, however converting to a Code cell
+  results in multiple cells.
   """
-  @callback to_source(attrs()) :: String.t()
+  @callback to_source(attrs()) :: String.t() | list(String.t())
 
   @doc """
   Invoked whenever the base evaluation context changes.


### PR DESCRIPTION
Allows `c:Kino.SmartCell.to_source/1` to return a list, then when converting to a Code cell, each chunk becomes its own cell.