### PR TITLE
Add `monospace` option to `Kino.Input.textarea`

### DIFF
--- a/lib/kino/input.ex
+++ b/lib/kino/input.ex
@@ -71,11 +71,19 @@ defmodule Kino.Input do
   ## Options
 
     * `:default` - the initial input value. Defaults to `""`
+    * `:monospace` - display the textarea's contents in a monospace font. Defaults to `false`
   """
   @spec textarea(String.t(), keyword()) :: t()
   def textarea(label, opts \\ []) when is_binary(label) and is_list(opts) do
     default = opts |> Keyword.get(:default, "") |> to_string()
-    new(%{type: :textarea, label: label, default: default})
+    monospace = opts |> Keyword.get(:monospace, false)
+
+    new(%{
+      type: :textarea,
+      label: label,
+      default: default,
+      monospace: monospace
+    })
   end
 
   @doc """

--- a/lib/kino/input.ex
+++ b/lib/kino/input.ex
@@ -71,7 +71,9 @@ defmodule Kino.Input do
   ## Options
 
     * `:default` - the initial input value. Defaults to `""`
-    * `:monospace` - display the textarea's contents in a monospace font. Defaults to `false`
+
+    * `:monospace` - whether to use a monospace font inside the textarea.
+      Defaults to `false`
   """
   @spec textarea(String.t(), keyword()) :: t()
   def textarea(label, opts \\ []) when is_binary(label) and is_list(opts) do

--- a/lib/kino/input.ex
+++ b/lib/kino/input.ex
@@ -78,7 +78,7 @@ defmodule Kino.Input do
   @spec textarea(String.t(), keyword()) :: t()
   def textarea(label, opts \\ []) when is_binary(label) and is_list(opts) do
     default = opts |> Keyword.get(:default, "") |> to_string()
-    monospace = opts |> Keyword.get(:monospace, false)
+    monospace = Keyword.get(opts, :monospace, false)
 
     new(%{
       type: :textarea,

--- a/lib/kino/output.ex
+++ b/lib/kino/output.ex
@@ -225,6 +225,7 @@ defmodule Kino.Output do
               id: input_id(),
               label: String.t(),
               default: String.t(),
+              monospace: boolean(),
               destination: Process.dest()
             }
           | %{


### PR DESCRIPTION
Allow `Kino.Input.textarea` inputs to be given a new option, `monospace`.
When `monospace` is set to `true`, this allows Livebook to render the textarea with a monospaced font.

This is to support https://github.com/livebook-dev/livebook/pull/1565

When combined with the pull request above it results in:

![image](https://user-images.githubusercontent.com/454563/205763004-2c9820ad-cebd-4d5c-9233-8eeb91669653.png)