### PR TITLE
Move Kino.Tree under the "Kinos" section in docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,8 @@ defmodule Kino.MixProject do
           Kino.Layout,
           Kino.Markdown,
           Kino.Mermaid,
-          Kino.Process
+          Kino.Process,
+          Kino.Tree
         ],
         Inputs: [
           Kino.Input,


### PR DESCRIPTION
Just noticed this in 0.8.0:

<img width="330" alt="Screenshot 2022-12-06 at 23 23 27" src="https://user-images.githubusercontent.com/8614029/206036586-d2e7984b-c51d-45af-9840-d1b3dcb05ab2.png">
