### PR TITLE
Add Kino.JS.Live.monitor/1

### DIFF
--- a/lib/kino/js/live.ex
+++ b/lib/kino/js/live.ex
@@ -360,4 +360,14 @@ defmodule Kino.JS.Live do
   def call(kino, term, timeout \\ 5_000) do
     Kino.JS.Live.Server.call(kino.pid, term, timeout)
   end
+
+  @doc """
+  Starts monitoring the kino server from the calling process.
+
+  Refer to `Process.monitor/1` for more details.
+  """
+  @spec monitor(t()) :: reference()
+  def monitor(kino) do
+    Process.monitor(kino.pid)
+  end
 end

--- a/test/kino/js/live_test.exs
+++ b/test/kino/js/live_test.exs
@@ -53,4 +53,12 @@ defmodule Kino.JS.LiveTest do
     send(kino.pid, {:ping, self(), :metadata, %{ref: ref}})
     assert_receive {:pong, :metadata, %{ref: ^ref}}
   end
+
+  test "monitor/1" do
+    %{pid: pid} = kino = LiveCounter.new(0)
+    ref = Kino.JS.Live.monitor(kino)
+    assert is_reference(ref)
+    Process.exit(pid, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :killed}
+  end
 end


### PR DESCRIPTION
Hello, Livebook devs! This is a very pass-thru function but given the opaque Live type I thought it might be acceptable :)

My use case is a [telemetry handler](https://github.com/mcrumm/kino_telemetry/commit/b981f90cda1534acc365357a501727d76ec387e4) that monitors a VegaLite chart and shuts down when the cell is re-evaluated.


