### PR TITLE
Support non-charlist List values in DataTable

### DIFF
--- a/lib/kino/data_table.ex
+++ b/lib/kino/data_table.ex
@@ -242,6 +242,15 @@ defmodule Kino.DataTable do
 
   defp value_to_string(value) when is_atom(value), do: inspect(value)
 
+  defp value_to_string(value) when is_list(value) do
+    try do
+      List.to_string(value)
+    rescue
+      ArgumentError ->
+        inspect(value)
+    end
+  end
+
   defp value_to_string(value) do
     if mod = String.Chars.impl_for(value), do: mod.to_string(value), else: inspect(value)
   end

--- a/test/kino/data_table_test.exs
+++ b/test/kino/data_table_test.exs
@@ -114,7 +114,7 @@ defmodule Kino.DataTableTest do
                data: [
                  [
                    <<1, 98>>,
-                   "[~N[2000-01-01 00:00:00], %Kino.DataTableTest.User{__meta__: nil, id: 1, name: \"User\"}]"
+                   ~s/[~N[2000-01-01 00:00:00], %Kino.DataTableTest.User{__meta__: nil, id: 1, name: "User"}]/
                  ]
                ]
              }

--- a/test/kino/data_table_test.exs
+++ b/test/kino/data_table_test.exs
@@ -98,6 +98,29 @@ defmodule Kino.DataTableTest do
            } = data
   end
 
+  test "supports non-charlist List values" do
+    entries = [
+      [
+        {"a", [1, "b"]},
+        {"b", [~N"2000-01-01 00:00:00", %User{id: 1, name: "User"}]}
+      ]
+    ]
+
+    kino = Kino.DataTable.new(entries)
+    data = connect(kino)
+
+    assert %{
+             content: %{
+               data: [
+                 [
+                   <<1, 98>>,
+                   "[~N[2000-01-01 00:00:00], %Kino.DataTableTest.User{__meta__: nil, id: 1, name: \"User\"}]"
+                 ]
+               ]
+             }
+           } = data
+  end
+
   test "sends only relevant fields if user-specified keys are given" do
     kino = Kino.DataTable.new(@people_entries, keys: [:id])
     data = connect(kino)


### PR DESCRIPTION
My SQL query smartcell crashed with the `List.to_string/1` `ArgumentError` exception when returning an `array_agg` list of timestamps from a postgres query.

This rescues the exception and applies the `value_to_string/1` to each list item before running the whole list through `inspect`.

The test checks for the standard charlist behaviour along with some non-standard values.