### PR TITLE
Change file access API

### DIFF
--- a/lib/kino/bridge.ex
+++ b/lib/kino/bridge.ex
@@ -46,18 +46,17 @@ defmodule Kino.Bridge do
   Note that the input must be known to Livebook, otherwise
   an error is returned.
   """
-  @spec get_input_value(String.t()) :: {:ok, term()} | {:error, request_error()}
+  @spec get_input_value(String.t()) :: {:ok, term()} | {:error, request_error() | :not_found}
   def get_input_value(input_id) do
-    with {:ok, reply} <- io_request({:livebook_get_input_value, input_id}) do
-      case reply do
-        {:ok, value} ->
-          {:ok, value}
+    with {:ok, reply} <- io_request({:livebook_get_input_value, input_id}), do: reply
+  end
 
-        {:error, :not_found} ->
-          raise ArgumentError,
-                "failed to read input value, no input found for id #{inspect(input_id)}"
-      end
-    end
+  @doc """
+  Requests the file path for the given file id.
+  """
+  @spec get_file_path(String.t()) :: {:ok, term()} | {:error, request_error() | :not_found}
+  def get_file_path(file_id) do
+    with {:ok, reply} <- io_request({:livebook_get_file_path, file_id}), do: reply
   end
 
   @doc """

--- a/lib/kino/input.ex
+++ b/lib/kino/input.ex
@@ -287,7 +287,7 @@ defmodule Kino.Input do
 
   Note that the value can also be `nil`, if no image is selected.
 
-  > ### Warning {.warning}
+  > #### Warning {: .warning}
   >
   > The image input is shared by default: once you upload a image,
   > the image will be replicated to all users reading the notebook.
@@ -370,7 +370,7 @@ defmodule Kino.Input do
 
   Note that the value can also be `nil`, if no audio is selected.
 
-  > ### Warning {.warning}
+  > #### Warning {: .warning}
   >
   > The audio input is shared by default: once you upload an audio,
   > the audio will be replicated to all users reading the notebook.
@@ -410,13 +410,15 @@ defmodule Kino.Input do
   The input value is a map, with the file path and metadata:
 
       %{
-        path: String.t(),
+        file_id: String.t(),
         client_name: String.t()
       }
 
   Note that the value can also be `nil`, if no file is selected.
 
-  > ### Warning {.warning}
+  The file path can then be accessed using `file_path/1`.
+
+  > #### Warning {: .warning}
   >
   > The file input is shared by default: once you upload a file,
   > the file will be replicated to all users reading the notebook.
@@ -468,6 +470,20 @@ defmodule Kino.Input do
 
       {:error, reason} ->
         raise "failed to read input value, reason: #{inspect(reason)}"
+    end
+  end
+
+  @doc """
+  Returns file path for the given file identifier.
+  """
+  @spec file_path(String.t()) :: String.t()
+  def file_path(file_id) do
+    case Kino.Bridge.get_file_path(file_id) do
+      {:ok, path} ->
+        path
+
+      {:error, reason} ->
+        raise "could not resolve the file path, reason: #{inspect(reason)}"
     end
   end
 end


### PR DESCRIPTION
The file input is now used as:

```elixir
value = Kino.Input.read(input)
path = Kino.Input.file_path(value.file_id)

File.read!(path)
```

See [TBA](https://github.com/livebook-dev/livebook/pull/1673) for more details.