### PR TITLE
Add automatic image detection

### DIFF
--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -157,14 +157,14 @@ end
 defimpl Kino.Render, for: BitString do
   def to_livebook(string) do
     case Kino.Utils.get_image_type(string) do
-      {:ok, type} ->
+      nil ->
+        Kino.Output.inspect(string)
+
+      type ->
         raw = Kino.Inspect.new(string)
         image = Kino.Image.new(string, type)
         tabs = Kino.Layout.tabs(Image: image, Raw: raw)
         Kino.Render.to_livebook(tabs)
-
-      _ ->
-        Kino.Output.inspect(string)
     end
   end
 end

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -153,3 +153,18 @@ defimpl Kino.Render, for: PID do
     end
   end
 end
+
+defimpl Kino.Render, for: BitString do
+  def to_livebook(string) do
+    case Kino.Utils.get_image_type(string) do
+      {:ok, type} ->
+        raw = Kino.Inspect.new(string)
+        image = Kino.Image.new(string, type)
+        tabs = Kino.Layout.tabs(Image: image, Raw: raw)
+        Kino.Render.to_livebook(tabs)
+
+      _ ->
+        Kino.Output.inspect(string)
+    end
+  end
+end

--- a/lib/kino/utils.ex
+++ b/lib/kino/utils.ex
@@ -42,19 +42,16 @@ defmodule Kino.Utils do
   end
 
   @doc """
-  Gets the image type of a file by the magic number
+  Determines image type looking for the magic number in the binary.
   """
-  @spec get_image_type(bitstring()) :: {:ok, Kino.Image.common_image_type()} | :not_found
-  def get_image_type(<<0xFF, 0xD8, 0xFF, 0xE0, _rest::binary>>), do: {:ok, :jpeg}
-
-  def get_image_type(<<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, _rest::binary>>),
-    do: {:ok, :png}
-
-  def get_image_type(<<0x3C, 0x3F, 0x78, 0x6D, 0x6C, 0x20, _rest::binary>>), do: {:ok, :svg}
+  @spec get_image_type(binary()) :: Kino.Image.common_image_type() | nil
+  def get_image_type(<<0xFF, 0xD8, 0xFF, 0xE0, _rest::binary>>), do: :jpeg
+  def get_image_type(<<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, _rest::binary>>), do: :png
+  def get_image_type(<<0x3C, 0x3F, 0x78, 0x6D, 0x6C, 0x20, _rest::binary>>), do: :svg
 
   def get_image_type(<<0x47, 0x49, 0x46, 0x38, x::8, 0x61, _rest::binary>>)
       when x in [0x37, 0x39],
-      do: {:ok, :gif}
+      do: :gif
 
-  def get_image_type(_image), do: :not_found
+  def get_image_type(_image), do: nil
 end

--- a/lib/kino/utils.ex
+++ b/lib/kino/utils.ex
@@ -44,20 +44,10 @@ defmodule Kino.Utils do
   @doc """
   Determines image type looking for the magic number in the binary.
   """
-<<<<<<< HEAD
   @spec get_image_type(binary()) :: Kino.Image.common_image_type() | nil
   def get_image_type(<<0xFF, 0xD8, 0xFF, 0xE0, _rest::binary>>), do: :jpeg
   def get_image_type(<<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, _rest::binary>>), do: :png
   def get_image_type(<<0x3C, 0x3F, 0x78, 0x6D, 0x6C, 0x20, _rest::binary>>), do: :svg
-=======
-  @spec image_type(binary()) :: Kino.Image.common_image_type() | nil
-  def get_image_type(<<0xFF, 0xD8, 0xFF, 0xE0, _rest::binary>>), do: {:ok, :jpeg}
-
-  def get_image_type(<<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, _rest::binary>>),
-    do: {:ok, :png}
-
-  def get_image_type(<<0x3C, 0x3F, 0x78, 0x6D, 0x6C, 0x20, _rest::binary>>), do: {:ok, :svg}
->>>>>>> 7a8c585fde01896986ae250ba6635fec29e6bcf0
 
   def get_image_type(<<0x47, 0x49, 0x46, 0x38, x::8, 0x61, _rest::binary>>)
       when x in [0x37, 0x39],

--- a/lib/kino/utils.ex
+++ b/lib/kino/utils.ex
@@ -40,4 +40,21 @@ defmodule Kino.Utils do
          do: true,
          else: (_ -> false)
   end
+
+  @doc """
+  Gets the image type of a file by the magic number
+  """
+  @spec get_image_type(bitstring()) :: {:ok, Kino.Image.common_image_type()} | :not_found
+  def get_image_type(<<0xFF, 0xD8, 0xFF, 0xE0, _rest::binary>>), do: {:ok, :jpeg}
+
+  def get_image_type(<<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, _rest::binary>>),
+    do: {:ok, :png}
+
+  def get_image_type(<<0x3C, 0x3F, 0x78, 0x6D, 0x6C, 0x20, _rest::binary>>), do: {:ok, :svg}
+
+  def get_image_type(<<0x47, 0x49, 0x46, 0x38, x::8, 0x61, _rest::binary>>)
+      when x in [0x37, 0x39],
+      do: {:ok, :gif}
+
+  def get_image_type(_image), do: :not_found
 end


### PR DESCRIPTION
This is my first time contributing to this project, and I'm excited to make my first pull request. Please let me know if there's anything I can improve!

Closes #43.

Detects image type by its magic number and renders the image as a tabbed output.
![kino_pr_add_automatic_image_detection](https://user-images.githubusercontent.com/11441198/224027535-ef0eb7ee-d5f1-432c-a3fd-00ab690850b3.png)

