### PR TITLE
Add concurrent listen

### DIFF
--- a/lib/kino.ex
+++ b/lib/kino.ex
@@ -329,10 +329,10 @@ defmodule Kino do
   end
 
   @doc ~S"""
-  Asynchronously consumes a stream with `fun`.
+  Consumes a stream with `fun` without blocking execution.
 
   Note that events are processed by `fun` sequentially. If you want
-  to process them concurrently, use `listen_all/2`.
+  to process them concurrently, use `async_listen/2`.
 
   ## Examples
 
@@ -374,44 +374,6 @@ defmodule Kino do
 
   def listen(stream, fun) when is_function(fun, 1) do
     async(fn -> Enum.each(stream, &safe_apply(fun, [&1], "Kino.listen")) end)
-  end
-
-  @doc """
-  Same as `listen/2`, except each event is processed concurrently.
-  """
-  @spec listen_all(Enumerable.t() | pos_integer(), (term() -> any())) :: :ok
-  def listen_all(stream_or_interval_ms, fun)
-
-  def listen_all(interval_ms, fun) when is_integer(interval_ms) and is_function(fun, 1) do
-    listen_all(Stream.interval(interval_ms), fun)
-  end
-
-  def listen_all(stream, fun) when is_function(fun, 1) do
-    async(fn ->
-      # For organization purposes we start all tasks under a separate
-      # supervisor and only that supervisor is started with Kino.start_child/1
-
-      start_fun = fn ->
-        {:ok, task_supervisor} = start_child(Task.Supervisor)
-        task_supervisor
-      end
-
-      reducer = fn event, task_supervisor ->
-        {[{event, task_supervisor}], task_supervisor}
-      end
-
-      after_fun = fn task_supervisor ->
-        DynamicSupervisor.terminate_child(Kino.DynamicSupervisor, task_supervisor)
-      end
-
-      stream
-      |> Stream.transform(start_fun, reducer, after_fun)
-      |> Enum.each(fn {event, task_supervisor} ->
-        Task.Supervisor.start_child(task_supervisor, fn ->
-          safe_apply(fun, [event], "Kino.listen_all")
-        end)
-      end)
-    end)
   end
 
   @doc ~S"""
@@ -482,6 +444,44 @@ defmodule Kino do
     end
 
     :ok
+  end
+
+  @doc """
+  Same as `listen/2`, except each event is processed concurrently.
+  """
+  @spec async_listen(Enumerable.t() | pos_integer(), (term() -> any())) :: :ok
+  def async_listen(stream_or_interval_ms, fun)
+
+  def async_listen(interval_ms, fun) when is_integer(interval_ms) and is_function(fun, 1) do
+    async_listen(Stream.interval(interval_ms), fun)
+  end
+
+  def async_listen(stream, fun) when is_function(fun, 1) do
+    async(fn ->
+      # For organization purposes we start all tasks under a separate
+      # supervisor and only that supervisor is started with Kino.start_child/1
+
+      start_fun = fn ->
+        {:ok, task_supervisor} = start_child(Task.Supervisor)
+        task_supervisor
+      end
+
+      reducer = fn event, task_supervisor ->
+        {[{event, task_supervisor}], task_supervisor}
+      end
+
+      after_fun = fn task_supervisor ->
+        DynamicSupervisor.terminate_child(Kino.DynamicSupervisor, task_supervisor)
+      end
+
+      stream
+      |> Stream.transform(start_fun, reducer, after_fun)
+      |> Enum.each(fn {event, task_supervisor} ->
+        Task.Supervisor.start_child(task_supervisor, fn ->
+          safe_apply(fun, [event], "Kino.async_listen")
+        end)
+      end)
+    end)
   end
 
   @doc """

--- a/test/kino_test.exs
+++ b/test/kino_test.exs
@@ -85,7 +85,7 @@ defmodule KinoTest do
   end
 
   describe "listen/2" do
-    test "asynchronously consumes stream items" do
+    test "consumes stream items" do
       myself = self()
 
       Stream.iterate(0, &(&1 + 1))
@@ -140,7 +140,7 @@ defmodule KinoTest do
   end
 
   describe "listen/3" do
-    test "asynchronously consumes stream items and accumulates state" do
+    test "consumes stream items and accumulates state" do
       myself = self()
 
       Stream.iterate(0, &(&1 + 1))
@@ -198,13 +198,13 @@ defmodule KinoTest do
     end
   end
 
-  describe "listen_all/2" do
+  describe "async_listen/2" do
     test "concurrently processes stream items" do
       myself = self()
 
       Stream.iterate(0, &(&1 + 1))
       |> Stream.take(2)
-      |> Kino.listen_all(fn i ->
+      |> Kino.async_listen(fn i ->
         send(myself, {:item, i})
         Process.sleep(:infinity)
       end)
@@ -218,7 +218,7 @@ defmodule KinoTest do
       myself = self()
       trace_subscription()
 
-      Kino.listen_all(button, fn event ->
+      Kino.async_listen(button, fn event ->
         send(myself, event)
         Process.sleep(:infinity)
       end)
@@ -241,7 +241,7 @@ defmodule KinoTest do
 
           Stream.iterate(0, &(&1 + 1))
           |> Stream.take(2)
-          |> Kino.listen_all(fn i ->
+          |> Kino.async_listen(fn i ->
             send(myself, {:item, self()})
             1 = i
           end)
@@ -252,7 +252,7 @@ defmodule KinoTest do
           await_process(pid2)
         end)
 
-      assert log =~ "Kino.listen_all"
+      assert log =~ "Kino.async_listen"
       assert log =~ "** (MatchError) no match of right hand side value: 0"
     end
   end


### PR DESCRIPTION
Adds a version of `listen/2` that processes all events concurrently in separate processes.