### PR TITLE
Support deferred reply in `Kino.JS.Live.handle_call/3`

### DIFF
--- a/lib/kino/js/live.ex
+++ b/lib/kino/js/live.ex
@@ -190,6 +190,8 @@ defmodule Kino.JS.Live do
 
   @type payload :: term() | {:binary, info :: term(), binary()}
 
+  @type from :: GenServer.from()
+
   @doc """
   Invoked when the server is started.
 
@@ -263,7 +265,7 @@ defmodule Kino.JS.Live do
 
   See `c:GenServer.handle_call/3` for more details.
   """
-  @callback handle_call(msg :: term(), from :: term(), ctx :: Context.t()) ::
+  @callback handle_call(msg :: term(), from(), ctx :: Context.t()) ::
               {:noreply, ctx :: Context.t()} | {:reply, term(), ctx :: Context.t()}
 
   @doc """
@@ -366,6 +368,20 @@ defmodule Kino.JS.Live do
   @spec call(t(), term(), timeout()) :: term()
   def call(kino, term, timeout \\ 5_000) do
     Kino.JS.Live.Server.call(kino.pid, term, timeout)
+  end
+
+  @doc """
+  Replies to the kino server.
+
+  This function can be used to explicitly send a reply to the kino server
+  that called `call/3` when the reply cannot be specified in the return
+  value of `handle_call/3`.
+
+  See `GenServer.reply/2` for more details.
+  """
+  @spec reply(from(), term()) :: :ok
+  def reply(kino, term) do
+    Kino.JS.Live.Server.reply(kino, term)
   end
 
   @doc """

--- a/lib/kino/js/live/server.ex
+++ b/lib/kino/js/live/server.ex
@@ -17,6 +17,8 @@ defmodule Kino.JS.Live.Server do
 
   defdelegate call(pid, term, timeout), to: GenServer
 
+  defdelegate reply(client, term), to: GenServer
+
   def broadcast_event(ctx, event, payload) do
     ref = ctx.__private__.ref
     Kino.Bridge.broadcast("js_live", ref, {:event, event, payload, %{ref: ref}})
@@ -47,8 +49,10 @@ defmodule Kino.JS.Live.Server do
 
   @impl true
   def handle_call(msg, from, state) do
-    {:reply, reply, ctx} = state.module.handle_call(msg, from, state.ctx)
-    {:reply, reply, %{state | ctx: ctx}}
+    case state.module.handle_call(msg, from, state.ctx) do
+      {:reply, reply, ctx} -> {:reply, reply, %{state | ctx: ctx}}
+      {:noreply, ctx} -> {:noreply, %{state | ctx: ctx}}
+    end
   end
 
   @impl true

--- a/test/kino/js/live_test.exs
+++ b/test/kino/js/live_test.exs
@@ -25,6 +25,13 @@ defmodule Kino.JS.LiveTest do
       assert count == 1
     end
 
+    test "handle_call/3 :noreply" do
+      kino = LiveCounter.new(0)
+      LiveCounter.bump(kino, 1)
+      count = LiveCounter.read_after(kino, 200)
+      assert count == 1
+    end
+
     test "handle_info/2" do
       kino = LiveCounter.new(0)
       send(kino.pid, {:ping, self()})

--- a/test/kino/js/live_test.exs
+++ b/test/kino/js/live_test.exs
@@ -28,7 +28,7 @@ defmodule Kino.JS.LiveTest do
     test "handle_call/3 :noreply" do
       kino = LiveCounter.new(0)
       LiveCounter.bump(kino, 1)
-      count = LiveCounter.read_after(kino, 200)
+      count = LiveCounter.read_after(kino, 0)
       assert count == 1
     end
 


### PR DESCRIPTION
Fix the wrong `JS.Live.handle_call/3` behavior, described in #273.