### PR TITLE
Fix premature cleanup of kinos pushed to frame asynchronously

### DIFF
--- a/lib/kino/test/group_leader.ex
+++ b/lib/kino/test/group_leader.ex
@@ -57,6 +57,11 @@ defmodule Kino.Test.GroupLeader do
     {:ok, "#cell:xyz"}
   end
 
+  defp io_request({:livebook_reference_object, object, pid}, state) do
+    send(state.target, {:livebook_reference_object, object, pid})
+    :ok
+  end
+
   defp io_request(_request, _state) do
     # Forward everything else to the default group leader
     :forward


### PR DESCRIPTION
Currently if a kino is crated inside `Kino.async_listen`, it is garbage collected as soon as the async process terminates, because the frame doesn't reference it on time.

```elixir
button = Kino.Control.button("Click")
frame = Kino.Frame.new()

Kino.async_listen(button, fn _event ->
  Kino.Frame.render(frame, Kino.HTML.new("Content"))
end)

Kino.Layout.grid([button, frame])
```

This makes frame render/append synchronous to make sure we send the reference request before the async process terminates.