### PR TITLE
Using listen instead of periodically

### DIFF
--- a/lib/kino.ex
+++ b/lib/kino.ex
@@ -287,29 +287,8 @@ defmodule Kino do
   def animate(stream_or_interval_ms, state, fun)
 
   def animate(interval_ms, state, fun) when is_integer(interval_ms) and is_function(fun, 2) do
-    frame = Kino.Frame.new()
-
-    stream =
-      Stream.interval(interval_ms)
-      |> Stream.take(interval_ms)
-
-    listen(stream, state, fn i, state ->
-      case safe_apply(fun, [i, state], "Kino.animate") do
-        {:ok, {:cont, term, state}} ->
-          Kino.Frame.render(frame, term)
-          {:cont, state}
-
-        {:ok, :halt} ->
-          :halt
-
-        {:error, _, _} ->
-          {:cont, state}
-      end
-    end)
-
-    Kino.render(frame)
-
-    nothing()
+    stream = Stream.interval(interval_ms) |> Stream.take(interval_ms)
+    animate(stream, state, fun)
   end
 
   def animate(stream, state, fun) when is_function(fun, 2) do

--- a/lib/kino.ex
+++ b/lib/kino.ex
@@ -289,17 +289,21 @@ defmodule Kino do
   def animate(interval_ms, state, fun) when is_integer(interval_ms) and is_function(fun, 2) do
     frame = Kino.Frame.new()
 
-    Kino.Frame.periodically(frame, interval_ms, {0, state}, fn {i, state} ->
+    stream =
+      Stream.interval(interval_ms)
+      |> Stream.take(interval_ms)
+
+    listen(stream, state, fn i, state ->
       case safe_apply(fun, [i, state], "Kino.animate") do
         {:ok, {:cont, term, state}} ->
           Kino.Frame.render(frame, term)
-          {:cont, {i + 1, state}}
+          {:cont, state}
 
         {:ok, :halt} ->
           :halt
 
         {:error, _, _} ->
-          {:cont, {i + 1, state}}
+          {:cont, state}
       end
     end)
 

--- a/lib/kino.ex
+++ b/lib/kino.ex
@@ -287,8 +287,7 @@ defmodule Kino do
   def animate(stream_or_interval_ms, state, fun)
 
   def animate(interval_ms, state, fun) when is_integer(interval_ms) and is_function(fun, 2) do
-    stream = Stream.interval(interval_ms) |> Stream.take(interval_ms)
-    animate(stream, state, fun)
+    animate(Stream.interval(interval_ms), state, fun)
   end
 
   def animate(stream, state, fun) when is_function(fun, 2) do


### PR DESCRIPTION
When interval ms is given to `Kino.animate` the `Kino.Frame.periodically` is being used with the `Kino.Frame.render` inside, which never returns because periodically blocks it.

This PR changes to use `listen` instead of `periodically`

Closes #280 