### PR TITLE
Deprecate Kino.Frame.periodically/4

### DIFF
--- a/test/kino/frame_test.exs
+++ b/test/kino/frame_test.exs
@@ -67,23 +67,4 @@ defmodule Kino.FrameTest do
     Kino.Frame.append(frame, 1)
     assert_output({:frame, [{:text, "\e[34m1\e[0m"}], %{type: :append}})
   end
-
-  test "periodically/4 evaluates the given callback in background until stopped" do
-    frame = Kino.Frame.new()
-
-    parent = self()
-
-    Kino.Frame.periodically(frame, 1, 1, fn n ->
-      if n < 3 do
-        send(parent, {:iteration, n})
-        {:cont, n + 1}
-      else
-        :halt
-      end
-    end)
-
-    assert_receive {:iteration, 1}
-    assert_receive {:iteration, 2}
-    refute_receive {:iteration, 3}, 5
-  end
 end


### PR DESCRIPTION
Initially we wanted to avoid additional process, but this eventually lead to issues (#280) and having this separate API in addition to `Kino.listen` and `Kino.animate` can be confusing.