### PR TITLE
Add Kino.Hub.app_info/0

### DIFF
--- a/lib/kino/bridge.ex
+++ b/lib/kino/bridge.ex
@@ -177,6 +177,14 @@ defmodule Kino.Bridge do
   end
 
   @doc """
+  Returns information about the running app.
+  """
+  @spec get_app_info() :: {:ok, map()} | {:error, request_error()}
+  def get_app_info() do
+    with {:ok, reply} <- io_request(:livebook_get_app_info), do: reply
+  end
+
+  @doc """
   Checks if the caller is running within Livebook context (group leader).
   """
   @spec within_livebook?() :: boolean()

--- a/lib/kino/hub.ex
+++ b/lib/kino/hub.ex
@@ -1,0 +1,33 @@
+defmodule Kino.Hub do
+  @moduledoc """
+  Functions related to hub integrations and Livebook apps.
+  """
+
+  @type app_info ::
+          %{type: :single}
+          | %{:type => :multi, optional(:creator) => user_info()}
+          | %{type: :none}
+
+  @type user_info :: %{
+          id: String.t(),
+          name: String.t() | nil,
+          email: String.t() | nil,
+          source: atom()
+        }
+
+  @doc """
+  Returns information about the running app.
+
+  Note that `:creator` information is only available for multi-session
+  apps when the app uses a Livebook Teams hub.
+
+  Unless called from withing an app deployment, returns `%{type: :none}`.
+  """
+  @spec app_info() :: app_info()
+  def app_info() do
+    case Kino.Bridge.get_app_info() do
+      {:ok, app_info} -> app_info
+      {:error, _} -> %{type: :none}
+    end
+  end
+end

--- a/lib/kino/hub.ex
+++ b/lib/kino/hub.ex
@@ -5,7 +5,7 @@ defmodule Kino.Hub do
 
   @type app_info ::
           %{type: :single}
-          | %{:type => :multi, optional(:creator) => user_info()}
+          | %{:type => :multi, optional(:started_by) => user_info()}
           | %{type: :none}
 
   @type user_info :: %{
@@ -18,7 +18,7 @@ defmodule Kino.Hub do
   @doc """
   Returns information about the running app.
 
-  Note that `:creator` information is only available for multi-session
+  Note that `:started_by` information is only available for multi-session
   apps when the app uses a Livebook Teams hub.
 
   Unless called from withing an app deployment, returns `%{type: :none}`.


### PR DESCRIPTION
Adds function to access information about the running app, in particular, when running with Teams hub it shows the user that started the session, useful for auditing purposes.