### PR TITLE
Kino.Input error messages

### DIFF
--- a/lib/kino/input.ex
+++ b/lib/kino/input.ex
@@ -277,7 +277,7 @@ defmodule Kino.Input do
 
     if min && max && NaiveDateTime.compare(min, max) == :gt do
       raise ArgumentError,
-            "expected :min to be less than :max, got: #{inspect(min)} and #{inspect(max)}"
+            "expected a non-empty range, but :min (#{inspect(min)}) is after :max (#{inspect(max)})"
     end
 
     assert_default_value!(
@@ -287,11 +287,13 @@ defmodule Kino.Input do
     )
 
     if min && default && NaiveDateTime.compare(default, min) == :lt do
-      raise ArgumentError, "expected :default to be bigger than :min, got: #{inspect(default)} "
+      raise ArgumentError,
+            "invalid :default, #{inspect(default)} is before :min (#{inspect(min)})"
     end
 
     if max && default && NaiveDateTime.compare(default, max) == :gt do
-      raise ArgumentError, "expected :default to be smaller than :max, got: #{inspect(default)}"
+      raise ArgumentError,
+            "invalid :default, #{inspect(default)} is after :max (#{inspect(max)})"
     end
 
     new(%{
@@ -333,17 +335,19 @@ defmodule Kino.Input do
 
     if min && max && Time.compare(min, max) == :gt do
       raise ArgumentError,
-            "expected :min to be less than :max, got: #{inspect(min)} and #{inspect(max)}"
+            "expected a non-empty range, but :min (#{inspect(min)}) is after :max (#{inspect(max)})"
     end
 
     assert_default_value!(default, "be %Time{} or nil", &(is_struct(&1, Time) or &1 == nil))
 
     if min && default && Time.compare(default, min) == :lt do
-      raise ArgumentError, "expected :default to be bigger than :min, got: #{inspect(default)}"
+      raise ArgumentError,
+            "invalid :default, #{inspect(default)} is before :min (#{inspect(min)})"
     end
 
     if max && default && Time.compare(default, max) == :gt do
-      raise ArgumentError, "expected :default to be smaller than :max, got: #{inspect(default)}"
+      raise ArgumentError,
+            "invalid :default, #{inspect(default)} is after :max (#{inspect(max)})"
     end
 
     new(%{
@@ -384,17 +388,19 @@ defmodule Kino.Input do
 
     if min && max && Date.compare(min, max) == :gt do
       raise ArgumentError,
-            "expected :min to be less than :max, got: #{inspect(min)} and #{inspect(max)}"
+            "expected a non-empty range, but :min (#{inspect(min)}) is after :max (#{inspect(max)})"
     end
 
     assert_default_value!(default, "be %Date{} or nil", &(is_struct(&1, Date) or &1 == nil))
 
     if min && default && Date.compare(default, min) == :lt do
-      raise ArgumentError, "expected :default to be bigger than :min, got: #{inspect(default)}"
+      raise ArgumentError,
+            "invalid :default, #{inspect(default)} is before :min (#{inspect(min)})"
     end
 
     if max && default && Date.compare(default, max) == :gt do
-      raise ArgumentError, "expected :default to be smaller than :max, got: #{inspect(default)}"
+      raise ArgumentError,
+            "invalid :default, #{inspect(default)} is after :max (#{inspect(max)})"
     end
 
     new(%{


### PR DESCRIPTION
Hi there!

@jonatanklosko was faster than I in addressing #325 with #326 -- thanks for the quick fix!

Since I had some changes laying around already, I decided to post them here for feedback/discussion, I wouldn't mind if they are eventually not accepted.

## ~~Tests~~

<details>

~~I noticed `Kino.Input.date` was lacking tests, and was happy to see @jonatanklosko added one yesterday!~~

~~I had a plan to cover more of the possible cases, and so tried some form of table-testing to reduce verbosity. I wonder how others see this type of test code in Elixir, given it also adds some cognitive complexity (`unquote`, `Macro.escape`, ...).~~

~~The constraints in this case are simple enough that property-based testing would also be a fun exercise :-)~~

</details>

Update: removed tests to keep the PR more focused.

## Error messages

Two out of three messages were missing part of what caused the error, making debugging unnecessarily harder.

I tried to make the messages more obvious and easier to interpret by a human when their Livebook cell is spitting out an error on them.

Something like `expected :min to be less than :max, got: #{inspect(min)} and #{inspect(max)}` is not exactly correct, as `:min` can also be *equal to* `:max`. If I were to continue the existing mathematical pattern, I'd write:

```
expected :min to be less than or equal :max, got: #{inspect(min)} and #{inspect(max)}
```

But, then, I thought why not simply state the problem directly: `:min is greater than :max`. And, when we talk about dates and time, I think the words "before" and "after" might be a better fit (might be a bias from my Go experience, where the [`time` package uses the words "before" and "after"](https://pkg.go.dev/time#Time.Compare)).

I would love to hear what are the Elixir-way ideas here, specially if there is a well establish preference.

If my changes are welcome, I could also update the other messages (time, etc) to match.