### PR TITLE
Bump versions in GitHub test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,18 +12,18 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: "1.15.2"
+              elixir: "1.15.5"
               otp: "26.0.2"
             lint: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.pair.otp}}
           elixir-version: ${{matrix.pair.elixir}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             deps


### PR DESCRIPTION
Fixes warning in recent workflow runs:

> The following actions uses node12 which is deprecated and will be forced
> to run on node16: actions/checkout@v2, actions/cache@v2.
>
> For more info:
> https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

Example run: https://github.com/livebook-dev/kino/actions/runs/6142008298