### PR TITLE
Add API for setting smart cell editor source and intellisense node

### DIFF
--- a/assets/remote_execution_cell/main.js
+++ b/assets/remote_execution_cell/main.js
@@ -233,21 +233,7 @@ export function init(ctx, payload) {
         const field = event.target.name;
         const value = this.fields[field];
         ctx.pushEvent("update_field", { field, value });
-        field !== "assign_to" && this.updateNodeInfo();
       },
-      updateNodeInfo() {
-        const node = this.fields["use_node_secret"]
-          ? this.fields["node_secret_value"]
-          : this.fields["node"];
-        const cookie = this.fields["use_cookie_secret"]
-          ? this.fields["cookie_secret_value"]
-          : this.fields["cookie"];
-        ctx.setSmartCellEditorIntellisenseNode(node, cookie);
-      },
-    },
-
-    mounted() {
-      this.updateNodeInfo();
     },
   }).mount(ctx.root);
 
@@ -255,33 +241,9 @@ export function init(ctx, payload) {
     setFields(fields);
   });
 
-  ctx.handleEvent("update_node_info", (secret_value) => {
-    const node =
-      "node_secret" in secret_value ? secret_value.node_secret : getNode();
-    const cookie =
-      "cookie_secret" in secret_value
-        ? secret_value.cookie_secret
-        : getCookie();
-    ctx.setSmartCellEditorIntellisenseNode(node, cookie);
-  });
-
   function setFields(fields) {
     for (const field in fields) {
       app.fields[field] = fields[field];
     }
-  }
-
-  function getNode() {
-    const node = app.fields["use_node_secret"]
-      ? app.fields["node_secret_value"]
-      : app.fields["node"];
-    return node;
-  }
-
-  function getCookie() {
-    const cookie = app.fields["use_cookie_secret"]
-      ? app.fields["cookie_secret_value"]
-      : app.fields["cookie"];
-    return cookie;
   }
 }

--- a/lib/assets/remote_execution_cell/build/main.js
+++ b/lib/assets/remote_execution_cell/build/main.js
@@ -20,7 +20,7 @@ function We(e,t){let n=new Set(e.split(","));return t?s=>n.has(s.toLowerCase()):
     <label class="inline-label">
       {{ label }}
     </label>
-    `},BaseSecret:{name:"BaseSecret",components:{BaseInput:n},props:{textInputName:{type:String,default:""},secretInputName:{type:String,default:""},toggleInputName:{type:String,default:""},label:{type:String,default:null},toggleInputValue:{type:[String,Number],default:""},secretInputValue:{type:[String,Number],default:""},textInputValue:{type:[String,Number],default:""},modalTitle:{type:String,default:"Select secret"},required:{type:Boolean,default:!1}},methods:{selectSecret(){let a=this.secretInputValue||"";e.selectSecret(u=>{e.pushEvent("update_field",{field:this.secretInputName,value:u}),this.$emit("update:secretInputValue",u)},a,{title:this.modalTitle})}},template:`
+    `},BaseSecret:{name:"BaseSecret",components:{BaseInput:n},props:{textInputName:{type:String,default:""},secretInputName:{type:String,default:""},toggleInputName:{type:String,default:""},label:{type:String,default:null},toggleInputValue:{type:[String,Number],default:""},secretInputValue:{type:[String,Number],default:""},textInputValue:{type:[String,Number],default:""},modalTitle:{type:String,default:"Select secret"},required:{type:Boolean,default:!1}},methods:{selectSecret(){let l=this.secretInputValue||"";e.selectSecret(c=>{e.pushEvent("update_field",{field:this.secretInputName,value:c}),this.$emit("update:secretInputValue",c)},l,{title:this.modalTitle})}},template:`
       <div class="input-icon-container">
         <BaseInput
           v-if="toggleInputValue"
@@ -105,7 +105,7 @@ function We(e,t){let n=new Set(e.split(","));return t?s=>n.has(s.toLowerCase()):
         </div>
       </form>
     </div>
-    `,data(){return{fields:t.fields}},methods:{handleFieldChange(a){let u=a.target.name,d=this.fields[u];e.pushEvent("update_field",{field:u,value:d}),u!=="assign_to"&&this.updateNodeInfo()},updateNodeInfo(){let a=this.fields.use_node_secret?this.fields.node_secret_value:this.fields.node,u=this.fields.use_cookie_secret?this.fields.cookie_secret_value:this.fields.cookie;e.setSmartCellEditorIntellisenseNode(a,u)}},mounted(){this.updateNodeInfo()}}).mount(e.root);e.handleEvent("update_field",({fields:a})=>{i(a)}),e.handleEvent("update_node_info",a=>{let u="node_secret"in a?a.node_secret:l(),d="cookie_secret"in a?a.cookie_secret:c();e.setSmartCellEditorIntellisenseNode(u,d)});function i(a){for(let u in a)r.fields[u]=a[u]}function l(){return r.fields.use_node_secret?r.fields.node_secret_value:r.fields.node}function c(){return r.fields.use_cookie_secret?r.fields.cookie_secret_value:r.fields.cookie}}export{wf as init};
+    `,data(){return{fields:t.fields}},methods:{handleFieldChange(l){let c=l.target.name,a=this.fields[c];e.pushEvent("update_field",{field:c,value:a})}}}).mount(e.root);e.handleEvent("update_field",({fields:l})=>{i(l)});function i(l){for(let c in l)r.fields[c]=l[c]}}export{wf as init};
 /*! #__NO_SIDE_EFFECTS__ */
 /**
 * vue v3.4.15

--- a/lib/kino/js/live/context.ex
+++ b/lib/kino/js/live/context.ex
@@ -98,4 +98,24 @@ defmodule Kino.JS.Live.Context do
   def emit_event(%__MODULE__{} = ctx, event) do
     Kino.JS.Live.Server.emit_event(ctx, event)
   end
+
+  @doc """
+  Updates smart cell configuration.
+
+  This function allows for re-configuring some of the options that can
+  be specified in smart cell's `c:Kino.JS.Live.init/2`.
+
+  Note that this function returns the new context, which you should
+  return from the given handler.
+
+  ## Options
+
+    * `:editor` - note that the smart cell must be initialized with an
+      editor during on init. Supported options: `:source`, `:intellisense_node`.
+
+  """
+  @spec reconfigure_smart_cell(t(), keyword()) :: t()
+  def reconfigure_smart_cell(%__MODULE__{} = ctx, opts) do
+    Kino.SmartCell.Server.reconfigure_smart_cell(ctx, opts)
+  end
 end

--- a/lib/kino/smart_cell.ex
+++ b/lib/kino/smart_cell.ex
@@ -169,6 +169,11 @@ defmodule Kino.SmartCell do
 
     * `:default_source` - the initial editor source. Defaults to `""`
 
+    * `:intellisense_node` - a `{node, cookie}` atom tuple specifying
+      a remote node that should be introspected for editor intellisense.
+      This is only applicable when `:language` is Elixir. Defaults to
+      `nil`
+
   ## Other options
 
   Other than the editor configuration, the following options are
@@ -257,6 +262,16 @@ defmodule Kino.SmartCell do
       @behaviour Kino.SmartCell
 
       @smart_opts opts
+
+      import Kino.JS.Live.Context,
+        only: [
+          assign: 2,
+          update: 3,
+          broadcast_event: 3,
+          send_event: 4,
+          emit_event: 2,
+          reconfigure_smart_cell: 2
+        ]
 
       @before_compile Kino.SmartCell
     end


### PR DESCRIPTION
Currently we set intellisense node through the client as `ctx.setSmartCellEditorIntellisenseNode(node, cookie)`, but if there are multiple clients we run this for each of them, which doesn't really make sense. I added a new option to the smart cell init configuration, so we can do `{:ok, ctx, [editor: [..., intellisense_node: ...]]}`, which sets the initial value. Then, it can be updated with a new API `reconfigure_smart_cell(ctx, editor: [intellisense_node: ...])`.

I also added an option to programmatically set the smart cell source with `reconfigure_smart_cell(ctx, editor: [source: ...])`.