### PR TITLE
Make the smart cell editor source explicitly managed

### DIFF
--- a/lib/kino/remote_execution_cell.ex
+++ b/lib/kino/remote_execution_cell.ex
@@ -41,13 +41,14 @@ defmodule Kino.RemoteExecutionCell do
 
     intellisense_node = intellisense_node(fields)
 
-    ctx = assign(ctx, fields: fields)
+    code = attrs["code"] || @default_code
+
+    ctx = assign(ctx, fields: fields, code: code)
 
     {:ok, ctx,
      editor: [
-       attribute: "code",
+       source: code,
        language: "elixir",
-       default_source: @default_code,
        intellisense_node: intellisense_node
      ]}
   end
@@ -98,8 +99,13 @@ defmodule Kino.RemoteExecutionCell do
   end
 
   @impl true
+  def handle_editor_change(source, ctx) do
+    {:ok, assign(ctx, code: source)}
+  end
+
+  @impl true
   def to_attrs(ctx) do
-    ctx.assigns.fields
+    Map.put(ctx.assigns.fields, "code", ctx.assigns.code)
   end
 
   @impl true


### PR DESCRIPTION
This is a breaking change, but I think it's better to do it sooner than later. Currently the user specifies under which `attr` the editor source should be placed and it is only available inside the `to_source(attrs)` callback. This PR makes the flow more explicit, we expose a new callback `handle_editor_change(source, ctx)` and it is up to the user to keep it in assigns and put in `attrs`. This could be used to update the UI based on the editor source (for example to parse the code and show errors).

Note that this is a breaking change only in that the smart cell implementation needs to be updated (a simple change). It doesn't change anything on Livebook side, and smart cell serialization is also not affected (provided the same attribute is used).