### PR TITLE
Convert container contents to output lazily

### DIFF
--- a/lib/kino/layout.ex
+++ b/lib/kino/layout.ex
@@ -3,11 +3,11 @@ defmodule Kino.Layout do
   Layout utilities for arranging multiple kinos together.
   """
 
-  defstruct [:type, :outputs, :info]
+  defstruct [:type, :items, :info]
 
   @opaque t :: %__MODULE__{
             type: :tabs | :grid,
-            outputs: list(Kino.Output.t()),
+            items: list(term()),
             info: map()
           }
 
@@ -31,9 +31,8 @@ defmodule Kino.Layout do
   def tabs(tabs) do
     {labels, terms} = Enum.unzip(tabs)
     labels = Enum.map(labels, &to_string/1)
-    outputs = Enum.map(terms, &Kino.Render.to_livebook/1)
     info = %{labels: labels}
-    %Kino.Layout{type: :tabs, outputs: outputs, info: info}
+    %Kino.Layout{type: :tabs, items: terms, info: info}
   end
 
   @doc """
@@ -65,7 +64,6 @@ defmodule Kino.Layout do
   @spec grid(list(term()), keyword()) :: t()
   def grid(terms, opts \\ []) do
     opts = Keyword.validate!(opts, columns: 1, boxed: false, gap: 8)
-    outputs = Enum.map(terms, &Kino.Render.to_livebook/1)
 
     info = %{
       columns: opts[:columns],
@@ -73,6 +71,6 @@ defmodule Kino.Layout do
       gap: opts[:gap]
     }
 
-    %Kino.Layout{type: :grid, outputs: outputs, info: info}
+    %Kino.Layout{type: :grid, items: terms, info: info}
   end
 end

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -103,20 +103,23 @@ defimpl Kino.Render, for: Kino.Frame do
 
   def to_livebook(kino) do
     Kino.Bridge.reference_object(kino.pid, self())
-    outputs = Kino.Frame.get_outputs(kino)
+    outputs = kino |> Kino.Frame.get_items() |> Enum.map(&Kino.Render.to_livebook/1)
     %{type: :frame, ref: kino.ref, outputs: outputs, placeholder: kino.placeholder}
   end
 end
 
 defimpl Kino.Render, for: Kino.Layout do
   def to_livebook(%{type: :tabs} = kino) do
-    %{type: :tabs, outputs: kino.outputs, labels: kino.info.labels}
+    outputs = Enum.map(kino.items, &Kino.Render.to_livebook/1)
+    %{type: :tabs, outputs: outputs, labels: kino.info.labels}
   end
 
   def to_livebook(%{type: :grid} = kino) do
+    outputs = Enum.map(kino.items, &Kino.Render.to_livebook/1)
+
     %{
       type: :grid,
-      outputs: kino.outputs,
+      outputs: outputs,
       columns: kino.info.columns,
       gap: kino.info.gap,
       boxed: kino.info.boxed

--- a/test/kino/frame_test.exs
+++ b/test/kino/frame_test.exs
@@ -29,7 +29,7 @@ defmodule Kino.FrameTest do
       %{type: :frame_update, update: {:replace, [%{type: :terminal_text, text: "\e[34m1\e[0m"}]}}
     )
 
-    assert Kino.Frame.get_outputs(frame) == []
+    assert Kino.Frame.get_items(frame) == []
   end
 
   test "render/2 sends output directly to clients when :temporary is true" do
@@ -42,7 +42,7 @@ defmodule Kino.FrameTest do
       update: {:replace, [%{type: :terminal_text, text: "\e[34m1\e[0m"}]}
     })
 
-    assert Kino.Frame.get_outputs(frame) == []
+    assert Kino.Frame.get_items(frame) == []
   end
 
   test "render/2 raises when :to and :temporary is disabled" do
@@ -86,5 +86,25 @@ defmodule Kino.FrameTest do
       type: :frame_update,
       update: {:append, [%{type: :terminal_text, text: "\e[34m1\e[0m"}]}
     })
+  end
+
+  test "Kino.Render.to_livebook/1 returns the current value for a nested frame" do
+    frame = Kino.Frame.new()
+
+    frame_inner = Kino.Frame.new()
+
+    Kino.Frame.render(frame, frame_inner)
+
+    assert %{
+             type: :frame,
+             outputs: [%{type: :frame, outputs: []}]
+           } = Kino.Render.to_livebook(frame)
+
+    Kino.Frame.render(frame_inner, 1)
+
+    assert %{
+             type: :frame,
+             outputs: [%{type: :frame, outputs: [%{type: :terminal_text, text: "\e[34m1\e[0m"}]}]
+           } = Kino.Render.to_livebook(frame)
   end
 end

--- a/test/kino/layout_test.exs
+++ b/test/kino/layout_test.exs
@@ -1,0 +1,47 @@
+defmodule Kino.LayoutTest do
+  use Kino.LivebookCase, async: true
+
+  describe "tabs" do
+    test "Kino.Render.to_livebook/1 returns the current value for a nested frame" do
+      frame_inner = Kino.Frame.new()
+
+      tabs = Kino.Layout.tabs(frame: frame_inner)
+
+      assert %{
+               type: :tabs,
+               outputs: [%{type: :frame, outputs: []}]
+             } = Kino.Render.to_livebook(tabs)
+
+      Kino.Frame.render(frame_inner, 1)
+
+      assert %{
+               type: :tabs,
+               outputs: [
+                 %{type: :frame, outputs: [%{type: :terminal_text, text: "\e[34m1\e[0m"}]}
+               ]
+             } = Kino.Render.to_livebook(tabs)
+    end
+  end
+
+  describe "grid" do
+    test "Kino.Render.to_livebook/1 returns the current value for a nested frame" do
+      frame_inner = Kino.Frame.new()
+
+      grid = Kino.Layout.grid([frame_inner])
+
+      assert %{
+               type: :grid,
+               outputs: [%{type: :frame, outputs: []}]
+             } = Kino.Render.to_livebook(grid)
+
+      Kino.Frame.render(frame_inner, 1)
+
+      assert %{
+               type: :grid,
+               outputs: [
+                 %{type: :frame, outputs: [%{type: :terminal_text, text: "\e[34m1\e[0m"}]}
+               ]
+             } = Kino.Render.to_livebook(grid)
+    end
+  end
+end

--- a/test/kino/tree_test.exs
+++ b/test/kino/tree_test.exs
@@ -186,7 +186,7 @@ defmodule Kino.TreeTest do
   defp tree(input) do
     %Kino.Layout{
       type: :grid,
-      outputs: [%{type: :js, js_view: %{ref: ref}}]
+      items: [%Kino.JS{ref: ref}]
     } = Kino.Tree.new(input)
 
     send(Kino.JS.DataStore, {:connect, self(), %{origin: "client:#{inspect(self())}", ref: ref}})


### PR DESCRIPTION
For frames `Kino.Output.to_livebook/2` returns an output with the current set of outputs. Currently containers (grid/tabs/frame) convert their contents to output eagerly, and so if the content representation changes, a future container render is not going to know about it. Example:

```elixir
frame_inner = Kino.Frame.new()
grid = Kino.Layout.grid([frame_inner])

Kino.Frame.render(frame_inner, "content")
grid
```

This PR makes the conversion lazy, so that containers store their contents as is, and only call `Kino.Output.to_livebook/2` on render.