### PR TITLE
`Kino.Tree`: auto-expand tuples of up to 6 elements

### DIFF
--- a/assets/tree/src/App.js
+++ b/assets/tree/src/App.js
@@ -44,7 +44,7 @@ function TreeNode({ node, level }) {
         </div>
         <div>
           {node.children && isExpanded ? (
-            <TextItems items={node.expanded.prefix} />
+            <TextItems items={node.expanded_before} />
           ) : (
             <TextItems items={node.content} />
           )}
@@ -60,7 +60,7 @@ function TreeNode({ node, level }) {
             ))}
           </ol>
           <div className="ml-[2ch]">
-            <TextItems items={node.expanded.suffix} />
+            <TextItems items={node.expanded_after} />
           </div>
         </>
       )}

--- a/assets/tree/src/App.js
+++ b/assets/tree/src/App.js
@@ -20,11 +20,11 @@ export default function App({ tree }) {
 }
 
 function TreeNode({ node, level }) {
-  const [expanded, setExpanded] = useState(shouldAutoExpand(node, level));
+  const [isExpanded, setIsExpanded] = useState(shouldAutoExpand(node, level));
 
   function handleExpandClick() {
     if (node.children) {
-      setExpanded(!expanded);
+      setIsExpanded(!isExpanded);
     }
   }
 
@@ -36,21 +36,21 @@ function TreeNode({ node, level }) {
       >
         <div className="mr-0.5 inline-block w-[2ch] flex-shrink-0">
           {node.children &&
-            (expanded ? (
+            (isExpanded ? (
               <RiArrowDownSFill size={20} />
             ) : (
               <RiArrowRightSFill size={20} />
             ))}
         </div>
         <div>
-          {node.children && expanded ? (
+          {node.children && isExpanded ? (
             <TextItems items={node.expanded.prefix} />
           ) : (
             <TextItems items={node.content} />
           )}
         </div>
       </div>
-      {node.children && expanded && (
+      {node.children && isExpanded && (
         <>
           <ol className="m-0 ml-[2ch] block list-none p-0">
             {node.children.map((child, index) => (

--- a/assets/tree/src/App.js
+++ b/assets/tree/src/App.js
@@ -2,6 +2,15 @@ import React, { useState } from "react";
 import { RiArrowDownSFill, RiArrowRightSFill } from "@remixicon/react";
 import classNames from "classnames";
 
+const MAX_AUTO_EXPAND_SIZE = 6;
+
+function shouldAutoExpand(node, level) {
+  return (
+    level === 1 ||
+    (node.kind === "tuple" && node.children?.length <= MAX_AUTO_EXPAND_SIZE)
+  );
+}
+
 export default function App({ tree }) {
   return (
     <div className="font-mono text-sm text-gray-500">
@@ -11,7 +20,7 @@ export default function App({ tree }) {
 }
 
 function TreeNode({ node, level }) {
-  const [expanded, setExpanded] = useState(level === 1);
+  const [expanded, setExpanded] = useState(shouldAutoExpand(node, level));
 
   function handleExpandClick() {
     if (node.children) {

--- a/lib/kino/tree.ex
+++ b/lib/kino/tree.ex
@@ -73,7 +73,8 @@ defmodule Kino.Tree do
       kind: "tuple",
       content: [black("{...}") | suffix],
       children: children,
-      expanded: %{prefix: [black("{")], suffix: [black("}") | suffix]}
+      expanded_before: [black("{")],
+      expanded_after: [black("}") | suffix]
     }
   end
 
@@ -95,7 +96,8 @@ defmodule Kino.Tree do
       kind: "list",
       content: [black("[...]") | suffix],
       children: children,
-      expanded: %{prefix: [black("[")], suffix: [black("]") | suffix]}
+      expanded_before: [black("[")],
+      expanded_after: [black("]") | suffix]
     }
   end
 
@@ -115,10 +117,8 @@ defmodule Kino.Tree do
         kind: "struct",
         content: [black("%"), blue(inspect(module)), black("{...}") | suffix],
         children: children,
-        expanded: %{
-          prefix: [black("%"), blue(inspect(module)), black("{")],
-          suffix: [black("}") | suffix]
-        }
+        expanded_before: [black("%"), blue(inspect(module)), black("{")],
+        expanded_after: [black("}") | suffix]
       }
     end
   end
@@ -135,7 +135,8 @@ defmodule Kino.Tree do
       kind: "map",
       content: [black("%{...}") | suffix],
       children: children,
-      expanded: %{prefix: [black("%{")], suffix: [black("}") | suffix]}
+      expanded_before: [black("%{")],
+      expanded_after: [black("}") | suffix]
     }
   end
 
@@ -154,11 +155,11 @@ defmodule Kino.Tree do
       end
 
     case to_node(value, suffix) do
-      %{content: content, expanded: %{prefix: prefix} = expanded} = node ->
+      %{content: content, expanded_before: expanded_before} = node ->
         %{
           node
           | content: [key_span, sep_span | content],
-            expanded: %{expanded | prefix: [key_span, sep_span | prefix]}
+            expanded_before: [key_span, sep_span | expanded_before]
         }
 
       %{content: content} = node ->

--- a/test/kino/tree_test.exs
+++ b/test/kino/tree_test.exs
@@ -21,7 +21,8 @@ defmodule Kino.TreeTest do
     assert %{
              kind: "tuple",
              content: "{...}",
-             expanded: %{prefix: "{", suffix: "}"},
+             expanded_before: "{",
+             expanded_after: "}",
              children: [
                %{kind: "number", content: "1", children: nil}
              ]
@@ -32,12 +33,14 @@ defmodule Kino.TreeTest do
     assert %{
              kind: "tuple",
              content: "{...}",
-             expanded: %{prefix: "{", suffix: "}"},
+             expanded_before: "{",
+             expanded_after: "}",
              children: [
                %{
                  kind: "tuple",
                  content: "{...}",
-                 expanded: %{prefix: "{", suffix: "}"},
+                 expanded_before: "{",
+                 expanded_after: "}",
                  children: [
                    %{kind: "number", content: "1", children: nil}
                  ]
@@ -50,13 +53,15 @@ defmodule Kino.TreeTest do
     assert %{
              kind: "tuple",
              content: "{...}",
-             expanded: %{prefix: "{", suffix: "}"},
+             expanded_before: "{",
+             expanded_after: "}",
              children: [
                %{kind: "number", content: "1,", children: nil},
                %{
                  kind: "tuple",
                  content: "{...},",
-                 expanded: %{prefix: "{", suffix: "},"},
+                 expanded_before: "{",
+                 expanded_after: "},",
                  children: [
                    %{kind: "atom", content: ":x,", children: nil},
                    %{kind: "atom", content: ":y", children: nil}
@@ -71,7 +76,8 @@ defmodule Kino.TreeTest do
     assert %{
              kind: "list",
              content: "[...]",
-             expanded: %{prefix: "[", suffix: "]"},
+             expanded_before: "[",
+             expanded_after: "]",
              children: [
                %{kind: "number", content: "1", children: nil}
              ]
@@ -82,7 +88,8 @@ defmodule Kino.TreeTest do
     assert %{
              kind: "list",
              content: "[...]",
-             expanded: %{prefix: "[", suffix: "]"},
+             expanded_before: "[",
+             expanded_after: "]",
              children: [
                %{kind: "atom", content: "foo: :bar", children: nil}
              ]
@@ -93,7 +100,8 @@ defmodule Kino.TreeTest do
     assert %{
              kind: "map",
              content: "%{...}",
-             expanded: %{prefix: "%{", suffix: "}"},
+             expanded_before: "%{",
+             expanded_after: "}",
              children: [
                %{kind: "atom", content: "foo: :bar", children: nil}
              ]
@@ -104,7 +112,8 @@ defmodule Kino.TreeTest do
     assert %{
              kind: "map",
              content: "%{...}",
-             expanded: %{prefix: "%{", suffix: "}"},
+             expanded_before: "%{",
+             expanded_after: "}",
              children: [
                %{kind: "binary", content: ~s("foo" => "bar"), children: nil}
              ]
@@ -115,7 +124,8 @@ defmodule Kino.TreeTest do
     assert %{
              kind: "map",
              content: "%{...}",
-             expanded: %{prefix: "%{", suffix: "}"},
+             expanded_before: "%{",
+             expanded_after: "}",
              children: [
                %{kind: "atom", content: "bar: :baz,", children: nil},
                %{kind: "atom", content: "foo: :oof", children: nil}
@@ -127,7 +137,8 @@ defmodule Kino.TreeTest do
     assert %{
              kind: "map",
              content: "%{...}",
-             expanded: %{prefix: "%{", suffix: "}"},
+             expanded_before: "%{",
+             expanded_after: "}",
              children: [
                %{kind: "atom", content: "{1, 2} => true", children: nil}
              ]
@@ -142,7 +153,8 @@ defmodule Kino.TreeTest do
     assert %{
              kind: "struct",
              content: "%Kino.TreeTest.User{...}",
-             expanded: %{prefix: "%Kino.TreeTest.User{", suffix: "}"},
+             expanded_before: "%Kino.TreeTest.User{",
+             expanded_after: "}",
              children: [
                %{kind: "binary", content: ~s(email: "user@example.com"), children: nil}
              ]
@@ -183,7 +195,8 @@ defmodule Kino.TreeTest do
   test "uses separate colors for keys and values" do
     assert %{
              content: [%{text: "[...]", color: nil}],
-             expanded: %{prefix: [%{text: "[", color: nil}], suffix: [%{text: "]", color: nil}]},
+             expanded_before: [%{text: "[", color: nil}],
+             expanded_after: [%{text: "]", color: nil}],
              children: [
                %{
                  content: [
@@ -225,14 +238,16 @@ defmodule Kino.TreeTest do
          %{
            content: content,
            children: children,
-           expanded: %{prefix: prefix, suffix: suffix} = expanded
+           expanded_before: expanded_before,
+           expanded_after: expanded_after
          } = node
        ) do
     %{
       node
       | content: text_of(content),
         children: Enum.map(children, &plaintext/1),
-        expanded: %{expanded | prefix: text_of(prefix), suffix: text_of(suffix)}
+        expanded_before: text_of(expanded_before),
+        expanded_after: text_of(expanded_after)
     }
   end
 

--- a/test/kino/tree_test.exs
+++ b/test/kino/tree_test.exs
@@ -2,40 +2,44 @@ defmodule Kino.TreeTest do
   use Kino.LivebookCase, async: true
 
   test "renders strings as string nodes" do
-    assert %{content: ~s("some string"), children: nil} = plaintext_tree("some string")
+    assert %{kind: "binary", content: ~s("some string"), children: nil} =
+             plaintext_tree("some string")
   end
 
   test "renders atoms as nodes with inspected value" do
-    assert %{content: ":foo", children: nil} = plaintext_tree(:foo)
-    assert %{content: ~s(:"I need quotes"), children: nil} = plaintext_tree(:"I need quotes")
-    assert %{content: "SomeModule", children: nil} = plaintext_tree(SomeModule)
+    assert %{kind: "atom", content: ":foo", children: nil} = plaintext_tree(:foo)
+    assert %{kind: "atom", content: ~s(:"quote me"), children: nil} = plaintext_tree(:"quote me")
+    assert %{kind: "atom", content: "SomeModule", children: nil} = plaintext_tree(SomeModule)
   end
 
   test "renders numbers as nodes with inspected value" do
-    assert %{content: "100", children: nil} = plaintext_tree(100)
-    assert %{content: "100.0", children: nil} = plaintext_tree(100.0)
+    assert %{kind: "number", content: "100", children: nil} = plaintext_tree(100)
+    assert %{kind: "number", content: "100.0", children: nil} = plaintext_tree(100.0)
   end
 
   test "renders tuples as nodes with children" do
     assert %{
+             kind: "tuple",
              content: "{...}",
              expanded: %{prefix: "{", suffix: "}"},
              children: [
-               %{content: "1", children: nil}
+               %{kind: "number", content: "1", children: nil}
              ]
            } = plaintext_tree({1})
   end
 
   test "handles deep nesting" do
     assert %{
+             kind: "tuple",
              content: "{...}",
              expanded: %{prefix: "{", suffix: "}"},
              children: [
                %{
+                 kind: "tuple",
                  content: "{...}",
                  expanded: %{prefix: "{", suffix: "}"},
                  children: [
-                   %{content: "1", children: nil}
+                   %{kind: "number", content: "1", children: nil}
                  ]
                }
              ]
@@ -44,80 +48,88 @@ defmodule Kino.TreeTest do
 
   test "adds trailing commas to all but last child" do
     assert %{
+             kind: "tuple",
              content: "{...}",
              expanded: %{prefix: "{", suffix: "}"},
              children: [
-               %{content: "1,", children: nil},
+               %{kind: "number", content: "1,", children: nil},
                %{
+                 kind: "tuple",
                  content: "{...},",
                  expanded: %{prefix: "{", suffix: "},"},
                  children: [
-                   %{content: ":x,", children: nil},
-                   %{content: ":y", children: nil}
+                   %{kind: "atom", content: ":x,", children: nil},
+                   %{kind: "atom", content: ":y", children: nil}
                  ]
                },
-               %{content: ":three", children: nil}
+               %{kind: "atom", content: ":three", children: nil}
              ]
            } = plaintext_tree({1, {:x, :y}, :three})
   end
 
   test "renders lists as nodes with children" do
     assert %{
+             kind: "list",
              content: "[...]",
              expanded: %{prefix: "[", suffix: "]"},
              children: [
-               %{content: "1", children: nil}
+               %{kind: "number", content: "1", children: nil}
              ]
            } = plaintext_tree([1])
   end
 
   test "renders keywords as nodes with key-value children" do
     assert %{
+             kind: "list",
              content: "[...]",
              expanded: %{prefix: "[", suffix: "]"},
              children: [
-               %{content: "foo: :bar", children: nil}
+               %{kind: "atom", content: "foo: :bar", children: nil}
              ]
            } = plaintext_tree(foo: :bar)
   end
 
   test "renders maps as nodes with key-value children" do
     assert %{
+             kind: "map",
              content: "%{...}",
              expanded: %{prefix: "%{", suffix: "}"},
              children: [
-               %{content: "foo: :bar", children: nil}
+               %{kind: "atom", content: "foo: :bar", children: nil}
              ]
            } = plaintext_tree(%{foo: :bar})
   end
 
   test "uses the arrow for non-atom keys" do
     assert %{
+             kind: "map",
              content: "%{...}",
              expanded: %{prefix: "%{", suffix: "}"},
              children: [
-               %{content: ~s("foo" => "bar"), children: nil}
+               %{kind: "binary", content: ~s("foo" => "bar"), children: nil}
              ]
            } = plaintext_tree(%{"foo" => "bar"})
   end
 
   test "sorts maps by key" do
     assert %{
+             kind: "map",
              content: "%{...}",
              expanded: %{prefix: "%{", suffix: "}"},
              children: [
-               %{content: "bar: :baz,", children: nil},
-               %{content: "foo: :oof", children: nil}
+               %{kind: "atom", content: "bar: :baz,", children: nil},
+               %{kind: "atom", content: "foo: :oof", children: nil}
              ]
            } = plaintext_tree(%{foo: :oof, bar: :baz})
   end
 
   test "uses Inspect protocol for compound keys" do
     assert %{
+             kind: "map",
              content: "%{...}",
              expanded: %{prefix: "%{", suffix: "}"},
              children: [
-               %{content: "{1, 2} => true", children: nil}
+               %{kind: "atom", content: "{1, 2} => true", children: nil}
              ]
            } = plaintext_tree(%{{1, 2} => true})
   end
@@ -128,25 +140,27 @@ defmodule Kino.TreeTest do
 
   test "renders structs as nodes with children" do
     assert %{
+             kind: "struct",
              content: "%Kino.TreeTest.User{...}",
              expanded: %{prefix: "%Kino.TreeTest.User{", suffix: "}"},
              children: [
-               %{content: ~s(email: "user@example.com"), children: nil}
+               %{kind: "binary", content: ~s(email: "user@example.com"), children: nil}
              ]
            } = plaintext_tree(%User{email: "user@example.com"})
   end
 
   test "uses special handling for regexes" do
-    assert %{content: "~r/foobar/", children: nil} = plaintext_tree(~r/foobar/)
-    assert %{content: "~r//", children: nil} = plaintext_tree(%Regex{})
+    assert %{kind: "regex", content: "~r/foobar/", children: nil} = plaintext_tree(~r/foobar/)
+    assert %{kind: "regex", content: "~r//", children: nil} = plaintext_tree(%Regex{})
   end
 
   test "uses the Inspect protocol for structs that implement it" do
-    assert %{content: "~D[2022-01-01]", children: nil} = plaintext_tree(Date.new!(2022, 1, 1))
+    assert %{kind: "struct", content: "~D[2022-01-01]", children: nil} =
+             plaintext_tree(Date.new!(2022, 1, 1))
   end
 
   test "renders other terms as string nodes using Inspect protocol" do
-    assert %{content: "#PID<" <> _rest, children: nil} = plaintext_tree(self())
+    assert %{kind: "other", content: "#PID<" <> _rest, children: nil} = plaintext_tree(self())
   end
 
   test "renders empty containers as leaf nodes" do

--- a/test/kino/tree_test.exs
+++ b/test/kino/tree_test.exs
@@ -234,6 +234,10 @@ defmodule Kino.TreeTest do
     Enum.map(list, &plaintext/1)
   end
 
+  defp plaintext(%{content: content, children: nil} = node) do
+    %{node | content: text_of(content)}
+  end
+
   defp plaintext(
          %{
            content: content,
@@ -249,10 +253,6 @@ defmodule Kino.TreeTest do
         expanded_before: text_of(expanded_before),
         expanded_after: text_of(expanded_after)
     }
-  end
-
-  defp plaintext(%{content: content, children: nil} = node) do
-    %{node | content: text_of(content)}
   end
 
   defp text_of(list) when is_list(list) do


### PR DESCRIPTION
Closes #387.

Auto-expand tuples of up to 6 elements in `Kino.Tree` by default.

I've introduced the following changes:
- Add `"kind"` (e.g. `"tuple"`, `"list"`, etc.) attribute to tree's data,
- Use the `"kind"` attribute to change the logic for auto-expanding data; this now makes it easy to apply the same logic to lists and maps (if desired),
- Flatten the structure of the tree data: introduce `"expanded_before"` and `"expanded_after"` attributes,
- Refactor the UI code: rename `expanded` and `setExpanded` to `isExpanded` and `setIsExpanded` to better fit JavaScript conventions,
- Refactor the backend code: introduce `leaf_node` and `branch_node` to ensure that we build consistent data (without introducing more structs/types).


<img width="930" alt="Screenshot 2024-02-18 at 11 49 22" src="https://github.com/livebook-dev/kino/assets/8614029/5cedec08-c5d4-4cb6-afdc-5c179ab9aad1">