### PR TITLE
Add doc examples about the chunk option of Kino.Text.new/2 and Kino.Markdown.new/2

### DIFF
--- a/lib/kino/markdown.ex
+++ b/lib/kino/markdown.ex
@@ -51,6 +51,29 @@ defmodule Kino.Markdown do
       are merged into a single text. This is useful for streaming content.
       Defaults to `false`
 
+  ## Examples
+
+  ### Using the `:chunk` option
+
+    Using a `Kino.Frame`.
+
+      frame = Kino.Frame.new() |> Kino.render()
+
+      for word <- ["who", " *let*", " `the`", " **dogs**", " out"] do
+        text = Kino.Markdown.new(word, chunk: true)
+        Kino.Frame.append(frame, text)
+        Process.sleep(250)
+      end
+
+    Without using a `Kino.Frame`.
+
+      for word <- ["who", " *let*", " `the`", " **dogs**", " out"] do
+        Kino.Markdown.new(word, chunk: true) |> Kino.render()
+        Process.sleep(250)
+      end
+
+      Kino.nothing()
+
   """
   @spec new(binary(), keyword()) :: t()
   def new(text, opts \\ []) do

--- a/lib/kino/markdown.ex
+++ b/lib/kino/markdown.ex
@@ -55,7 +55,7 @@ defmodule Kino.Markdown do
 
   ### Using the `:chunk` option
 
-    Using a `Kino.Frame`.
+  Using a `Kino.Frame`.
 
       frame = Kino.Frame.new() |> Kino.render()
 
@@ -65,7 +65,7 @@ defmodule Kino.Markdown do
         Process.sleep(250)
       end
 
-    Without using a `Kino.Frame`.
+  Without using a `Kino.Frame`.
 
       for word <- ["who", " *let*", " `the`", " **dogs**", " out"] do
         Kino.Markdown.new(word, chunk: true) |> Kino.render()

--- a/lib/kino/text.ex
+++ b/lib/kino/text.ex
@@ -41,7 +41,7 @@ defmodule Kino.Text do
 
   ### Using the `:chunk` option
 
-    Using a `Kino.Frame`.
+  Using a `Kino.Frame`.
 
       frame = Kino.Frame.new() |> Kino.render()
 
@@ -51,7 +51,7 @@ defmodule Kino.Text do
         Process.sleep(250)
       end
 
-    Without using a `Kino.Frame`.
+  Without using a `Kino.Frame`.
 
       for word <- ["who", " let", " the", " dogs", " out"] do
         Kino.Text.new(word, chunk: true) |> Kino.render()

--- a/lib/kino/text.ex
+++ b/lib/kino/text.ex
@@ -37,6 +37,29 @@ defmodule Kino.Text do
       are merged into a single text. This is useful for streaming content.
       Defaults to `false`
 
+  ## Examples
+
+  ### Using the `:chunk` option
+
+    Using a `Kino.Frame`.
+
+      frame = Kino.Frame.new() |> Kino.render()
+
+      for word <- ["who", " let", " the", " dogs", " out"] do
+        text = Kino.Text.new(word, chunk: true)
+        Kino.Frame.append(frame, text)
+        Process.sleep(250)
+      end
+
+    Without using a `Kino.Frame`.
+
+      for word <- ["who", " let", " the", " dogs", " out"] do
+        Kino.Text.new(word, chunk: true) |> Kino.render()
+        Process.sleep(250)
+      end
+
+      Kino.nothing()
+
   """
   @spec new(String.t(), opts) :: t() when opts: [terminal: boolean(), chunk: boolean()]
   def new(text, opts \\ []) when is_binary(text) do


### PR DESCRIPTION
A user asked in the Slack channel about how to use the chunk option. I noticed there were no examples in the docs. So I copied the examples [from the original PR adding that option](https://github.com/livebook-dev/livebook/pull/2174) to the docs.