### PR TITLE
Custom Label Logic

### DIFF
--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -486,7 +486,6 @@ defmodule Kino.Process do
   defp label_from_value(tuple) when is_tuple(tuple), do: "tuple"
   defp label_from_value(_), do: "term"
 
-  @spec label_from_options(keyword) :: (any() -> label_response)
   defp label_from_options(opts) do
     opts
     |> Keyword.get(:message_label, fn _message -> :continue end)

--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -225,6 +225,13 @@ defmodule Kino.Process do
   target argument can either be a single PID, a list of PIDs, or the atom `:all`
   depending on what messages you would like to retain in your trace.
 
+  ## Options
+
+    * `:message_label` - A function to help label message events. If
+      the given function returns `:continue`, then the default label
+      is used. However, if the function returns a `String.t()`, then
+      that will be used for the label.
+
   ## Examples
 
   To generate a trace of all the messages occurring during the execution of the


### PR DESCRIPTION
This topic addresses #408

I added an extra argument to `seq_trace` and `render_seq_trace`, that accepts an extra argument to augment the labeling logic.

I have not tested the code yet, nor did I see any tests in the repo.

I hope it works.

I am now going to test this in a project I'm working on, and might add an extra commit that augments the example, showing off what the custom label can do.

I've also exposed `label_from_value` as I think it may add some value to people's custom's logic's

```elixir
  @spec foo(term()) :: label_response()
  defp foo(message) do
    case message do
      {:"$gen_call", _ref, {:special, _, msg}} -> "CALL: #{label_from_value(msg)}"
      {:"$gen_cast", _ref, {:special, _, msg}} -> "CAST: #{label_from_value(msg)}"
      _ -> :continue
    end
  end
```

is one such logic I used in mocking up what I wanted to do. I will get a better example as I make more examples.