### PR TITLE
Rename "Kino implementations" to "Built-in Kinos"

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -68,7 +68,7 @@ defmodule Kino.MixProject do
         # Kino.Input
         # Kino.Process
         # Kino.Shorts
-        "Kino implementations": [
+        "Built-in Kinos": [
           Kino.Audio,
           Kino.DataTable,
           Kino.Download,


### PR DESCRIPTION
I think this group header is a little more self-evident and is also consistent with the [Kino module doc](https://hexdocs.pm/kino/Kino.html#module-built-in-kinos).