### PR TITLE
Render ets tables

### DIFF
--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -727,9 +727,7 @@ defmodule Kino.Process do
   end
 
   defp graph_node(%{idx: idx, id: id, meta: %{protection: protection}, type: :ets}) do
-    """
-    #{idx}[("`#{module_or_atom_to_string(id)}\n**_#{protection}_**`")]:::ets
-    """
+    "#{idx}[(\"`#{module_or_atom_to_string(id)}\n**_#{protection}_**`\")]:::ets"
   end
 
   defp graph_node(%{idx: idx, pid: pid, type: type}) do


### PR DESCRIPTION
This PR addresses https://github.com/livebook-dev/kino/issues/430

By default, ETS table rendering is disabled and the rendering looks as it already does:
<img width="909" alt="image" src="https://github.com/livebook-dev/kino/assets/4753634/a71cf526-6c89-41ee-8f8a-4e5a91e20032">

If you enable ETS table rendering you see the following:
<img width="926" alt="image" src="https://github.com/livebook-dev/kino/assets/4753634/205dcaf0-f269-4b33-b646-43359c67dbd3">

At the moment this PR is lacking tests and could use a little refactoring, but I want to make sure the diagrams are right before writing the tests and performing last mile clean up.