### PR TITLE
New color for process on supervision tree rendering

### DIFF
--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -10,7 +10,7 @@ defmodule Kino.Process do
   @mermaid_classdefs """
   classDef root fill:#c4b5fd, stroke:#374151, stroke-width:4px;
   classDef supervisor fill:#c4b5fd, stroke:#374151, stroke-width:1px;
-  classDef worker fill:#93c5fd, stroke:#374151, stroke-width:1px;
+  classDef worker fill:#66c2a5, stroke:#374151, stroke-width:1px;
   classDef notstarted color:#777, fill:#d9d9d9, stroke:#777, stroke-width:1px;
   classDef ets fill:#a5f3fc, stroke:#374151, stroke-width:1px;
   """


### PR DESCRIPTION
The color of a worker was hard to distinguish from the color of a supervisor for some people (myself, for example).

Maybe it's hard for me to distinguish between them because I have a low level of color blindness.

## Before

![CleanShot 2024-06-04 at 15 49 01](https://github.com/livebook-dev/kino/assets/2719/6707ed8f-fc0c-4c40-8472-14ea013f414b)

## After

![CleanShot 2024-06-04 at 15 48 23](https://github.com/livebook-dev/kino/assets/2719/df8d4601-449c-42b3-809b-f69242bdc814)

I came up with the new color value by asking ChatGPT for a color that would be colorblind-friendly, given we would maintain the color of a supervisor in the graph.