### PR TITLE
Fix dbg pipeline when result renders as Kino.JS.Live

### DIFF
--- a/lib/kino/debug/pipeline.ex
+++ b/lib/kino/debug/pipeline.ex
@@ -31,6 +31,8 @@ defmodule Kino.Debug.Pipeline do
 
     %{id: last_id} = List.last(items)
 
+    send(self(), :update_result_frame)
+
     {:ok,
      ctx
      |> assign(
@@ -44,8 +46,7 @@ defmodule Kino.Debug.Pipeline do
        error: nil,
        call_count: 1,
        changed?: false
-     )
-     |> update_result_frame()}
+     )}
   end
 
   @impl true
@@ -125,6 +126,10 @@ defmodule Kino.Debug.Pipeline do
     ctx = update(ctx, :call_count, &(&1 + 1))
     broadcast_event(ctx, "call_count_updated", %{"call_count" => ctx.assigns.call_count})
     {:noreply, ctx}
+  end
+
+  def handle_info(:update_result_frame, ctx) do
+    {:noreply, update_result_frame(ctx)}
   end
 
   defp handle_items_change(ctx, items) do

--- a/test/kino/debug_test.exs
+++ b/test/kino/debug_test.exs
@@ -54,6 +54,23 @@ defmodule Kino.Debug.Test do
       assert dbg_line == __ENV__.line - 28
     end
 
+    test "initial render with result requiring Kino.start_child/1" do
+      # Rendering %UserAsTable{} creates a Kino.JS.Live
+      call_dbg(
+        %UserAsTable{id: 1}
+        |> Map.replace!(:id, 2)
+        |> Map.replace!(:id, 3)
+      )
+
+      {_kino, _output, frame_ref} = assert_dbg_pipeline_render()
+
+      assert_output(%{
+        type: :frame_update,
+        ref: ^frame_ref,
+        update: {:replace, [%{type: :js}]}
+      })
+    end
+
     test "updates result when a pipeline step is disabled" do
       call_dbg(
         1..5

--- a/test/support/test_modules/user_as_table.ex
+++ b/test/support/test_modules/user_as_table.ex
@@ -1,0 +1,9 @@
+defmodule UserAsTable do
+  defstruct [:id]
+
+  defimpl Kino.Render do
+    def to_livebook(user) do
+      Kino.DataTable.new([%{id: user.id}]) |> Kino.Render.to_livebook()
+    end
+  end
+end


### PR DESCRIPTION
Currently a pipeline with Explorer operations and `|> dbg()` hangs and times out. The pipeline `c:Kino.JS.Live.init/1` calls `Kino.Frame.render/2`, which may result in `Kino.start_child/1` underneath. In the past `Kino.Frame.render/2` used `GenServer.cast`, so the `init` callback would not block, finish and unlock the other `Kino.start_child/1`. However, we changed `Kino.Frame.render/2` to use `GenServer.call` (https://github.com/livebook-dev/kino/commit/aae7a1b0a22f1b5273a5d058c5831b916513438d), so now `init` blocks, but the nested `Kino.start_child/1` hangs, until `init` times out.

To fix it, I moved `Kino.Frame.render/2` from `init` to a subsequent `handle_info`.