### PR TITLE
Don't show :undefined id when rendering supervision trees

### DIFF
--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -764,7 +764,7 @@ defmodule Kino.Process do
         {:registered_name, []} ->
           case get_label(pid) do
             :undefined ->
-              if idx == 0 do
+              if idx == 0 || id == :undefined do
                 inspect(pid)
               else
                 # Use worker/supervisor id as label

--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -764,7 +764,7 @@ defmodule Kino.Process do
         {:registered_name, []} ->
           case get_label(pid) do
             :undefined ->
-              if idx == 0 || id == :undefined do
+              if idx == 0 or id == :undefined do
                 inspect(pid)
               else
                 # Use worker/supervisor id as label


### PR DESCRIPTION
## Before

![image](https://github.com/livebook-dev/kino/assets/2719/3dd1d15a-8b87-439d-a71f-c161d6934889)


## After

![image](https://github.com/livebook-dev/kino/assets/2719/9ff62291-56e5-4a17-8436-e0a8d74afbbb)
