### PR TITLE
Add play and pause to audio

### DIFF
--- a/lib/assets/audio/main.js
+++ b/lib/assets/audio/main.js
@@ -4,6 +4,10 @@ export function init(ctx, [{ type, opts }, content]) {
       <audio ${opts} src="${createDataUrl(content, type)}" style="height: 150px"/>
     </div>
   `;
+
+  ctx.handleEvent("play", () => {
+    ctx.root.querySelector("audio").play();
+  });
 }
 
 function bufferToBase64(buffer) {

--- a/lib/assets/audio/main.js
+++ b/lib/assets/audio/main.js
@@ -6,11 +6,11 @@ export function init(ctx, [{ type, opts }, content]) {
   `;
 
   ctx.handleEvent("play", () => {
-    ctx.root.querySelector("#audio").play();
+    ctx.root.querySelector("audio").play();
   });
 
   ctx.handleEvent("pause", () => {
-    ctx.root.querySelector("#audio").pause();
+    ctx.root.querySelector("audio").pause();
   });
 }
 

--- a/lib/assets/audio/main.js
+++ b/lib/assets/audio/main.js
@@ -8,6 +8,10 @@ export function init(ctx, [{ type, opts }, content]) {
   ctx.handleEvent("play", () => {
     ctx.root.querySelector("audio").play();
   });
+
+  ctx.handleEvent("pause", () => {
+    ctx.root.querySelector("audio").pause();
+  });
 }
 
 function bufferToBase64(buffer) {

--- a/lib/assets/audio/main.js
+++ b/lib/assets/audio/main.js
@@ -5,12 +5,14 @@ export function init(ctx, [{ type, opts }, content]) {
     </div>
   `;
 
+  const audioEl = ctx.root.querySelector("audio");
+
   ctx.handleEvent("play", () => {
-    ctx.root.querySelector("audio").play();
+    audioEl.play();
   });
 
   ctx.handleEvent("pause", () => {
-    ctx.root.querySelector("audio").pause();
+    audioEl.pause();
   });
 }
 

--- a/lib/assets/audio/main.js
+++ b/lib/assets/audio/main.js
@@ -6,11 +6,11 @@ export function init(ctx, [{ type, opts }, content]) {
   `;
 
   ctx.handleEvent("play", () => {
-    ctx.root.querySelector("audio").play();
+    ctx.root.querySelector("#audio").play();
   });
 
   ctx.handleEvent("pause", () => {
-    ctx.root.querySelector("audio").pause();
+    ctx.root.querySelector("#audio").pause();
   });
 }
 

--- a/lib/kino/audio.ex
+++ b/lib/kino/audio.ex
@@ -65,7 +65,7 @@ defmodule Kino.Audio do
   """
   @spec play(t()) :: :ok
   def play(kino) do
-    Kino.JS.Live.cast(kino, {:play})
+    Kino.JS.Live.cast(kino, :play)
   end
 
   @doc """
@@ -73,7 +73,7 @@ defmodule Kino.Audio do
   """
   @spec pause(t()) :: :ok
   def pause(kino) do
-    Kino.JS.Live.cast(kino, {:pause})
+    Kino.JS.Live.cast(kino, :pause)
   end
 
   @impl true
@@ -88,13 +88,12 @@ defmodule Kino.Audio do
   end
 
   @impl true
-  def handle_cast({:play}, ctx) do
+  def handle_cast(:play, ctx) do
     broadcast_event(ctx, "play", %{})
     {:noreply, ctx}
   end
 
-  @impl true
-  def handle_cast({:pause}, ctx) do
+  def handle_cast(:pause, ctx) do
     broadcast_event(ctx, "pause", %{})
     {:noreply, ctx}
   end

--- a/lib/kino/audio.ex
+++ b/lib/kino/audio.ex
@@ -68,6 +68,14 @@ defmodule Kino.Audio do
     Kino.JS.Live.cast(kino, {:play})
   end
 
+  @doc """
+  Makes a given kino stop playing the audio.
+  """
+  @spec pause(t()) :: :ok
+  def pause(kino) do
+    Kino.JS.Live.cast(kino, {:pause})
+  end
+
   @impl true
   def init(assigns, ctx) do
     {:ok, assign(ctx, assigns)}
@@ -82,6 +90,12 @@ defmodule Kino.Audio do
   @impl true
   def handle_cast({:play}, ctx) do
     broadcast_event(ctx, "play", %{})
+    {:noreply, ctx}
+  end
+
+  @impl true
+  def handle_cast({:pause}, ctx) do
+    broadcast_event(ctx, "pause", %{})
     {:noreply, ctx}
   end
 

--- a/lib/kino/audio.ex
+++ b/lib/kino/audio.ex
@@ -58,6 +58,16 @@ defmodule Kino.Audio do
     })
   end
 
+  @doc """
+  Makes a given kino play the audio.
+
+  Play has no effect if the audio is already playing.
+  """
+  @spec play(t()) :: :ok
+  def play(kino) do
+    Kino.JS.Live.cast(kino, {:play})
+  end
+
   @impl true
   def init(assigns, ctx) do
     {:ok, assign(ctx, assigns)}
@@ -67,6 +77,12 @@ defmodule Kino.Audio do
   def handle_connect(%{assigns: %{content: content, type: type, opts: opts}} = ctx) do
     payload = {:binary, %{type: type, opts: opts}, content}
     {:ok, payload, ctx}
+  end
+
+  @impl true
+  def handle_cast({:play}, ctx) do
+    broadcast_event(ctx, "play", %{})
+    {:noreply, ctx}
   end
 
   defp mime_type!(:wav), do: "audio/wav"

--- a/test/kino/audio_test.exs
+++ b/test/kino/audio_test.exs
@@ -27,5 +27,11 @@ defmodule Kino.AudioTest do
       kino = Kino.Audio.new(<<>>, "audio/mp2", loop: true)
       assert {:binary, %{type: "audio/mp2", opts: "controls loop"}, <<>>} == connect(kino)
     end
+
+    test "broadcasts play to javascript" do
+      kino = Kino.Audio.new(<<>>, :wav)
+      Kino.Audio.play(kino)
+      assert_broadcast_event(kino, "play", %{})
+    end
   end
 end

--- a/test/kino/audio_test.exs
+++ b/test/kino/audio_test.exs
@@ -28,13 +28,13 @@ defmodule Kino.AudioTest do
       assert {:binary, %{type: "audio/mp2", opts: "controls loop"}, <<>>} == connect(kino)
     end
 
-    test "broadcasts play to javascript" do
+    test "supports playing" do
       kino = Kino.Audio.new(<<>>, :wav)
       Kino.Audio.play(kino)
       assert_broadcast_event(kino, "play", %{})
     end
 
-    test "broadcasts pause to javascript" do
+    test "supports pausing" do
       kino = Kino.Audio.new(<<>>, :wav)
       Kino.Audio.pause(kino)
       assert_broadcast_event(kino, "pause", %{})

--- a/test/kino/audio_test.exs
+++ b/test/kino/audio_test.exs
@@ -33,5 +33,11 @@ defmodule Kino.AudioTest do
       Kino.Audio.play(kino)
       assert_broadcast_event(kino, "play", %{})
     end
+
+    test "broadcasts pause to javascript" do
+      kino = Kino.Audio.new(<<>>, :wav)
+      Kino.Audio.pause(kino)
+      assert_broadcast_event(kino, "pause", %{})
+    end
   end
 end


### PR DESCRIPTION
Addresses https://github.com/livebook-dev/kino/issues/457 

Adds support for `play` and `pause` functions for `Kino.Audio`.

I have tested it with:

# Untitled notebook

## Section

```elixir
req =
  Req.get!(
    "https://file-examples.com/storage/fe9f6f893066954d9aac3a2/2017/11/file_example_MP3_5MG.mp3"
  )

kino = Kino.Audio.new(req.body, :mp3)
```

```elixir
for n <- 0..11 do
  case rem(n, 2) do
    0 -> Kino.Audio.play(kino)
    1 -> Kino.Audio.pause(kino)
  end

  :timer.sleep(1000)
end
```