### PR TITLE
Support specifying column ratios in `Kino.Layout.grid`

### DIFF
--- a/lib/kino/layout.ex
+++ b/lib/kino/layout.ex
@@ -51,6 +51,10 @@ defmodule Kino.Layout do
     * `:gap` - the amount of spacing between grid items in pixels.
       Defaults to `8`
 
+    * `:template` - the [`grid-template-columns`](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns)
+      style property.
+      Defaults to `repeat(\#\{assigns.columns\}, minmax(0, 1fr))`
+
   ## Examples
 
       images =
@@ -63,12 +67,24 @@ defmodule Kino.Layout do
   """
   @spec grid(list(term()), keyword()) :: t()
   def grid(terms, opts \\ []) when is_list(terms) do
-    opts = Keyword.validate!(opts, columns: 1, boxed: false, gap: 8)
+    opts =
+      Keyword.validate!(opts,
+        columns: 1,
+        boxed: false,
+        gap: 8,
+        template:
+          "repeat(#{if opts[:columns] do
+            opts[:columns]
+          else
+            1
+          end}}, minmax(0, 1fr))"
+      )
 
     info = %{
       columns: opts[:columns],
       boxed: opts[:boxed],
-      gap: opts[:gap]
+      gap: opts[:gap],
+      template: opts[:template]
     }
 
     %Kino.Layout{type: :grid, items: terms, info: info}

--- a/lib/kino/layout.ex
+++ b/lib/kino/layout.ex
@@ -43,17 +43,14 @@ defmodule Kino.Layout do
 
   ## Options
 
-    * `:columns` - the number of columns in the grid. Defaults to `1`
+    * `:columns` - the number of columns in the grid. Optionally, supports a tuple of relative column widths, e.g:
+      {4,3,8}, for three columns, with the last twice as wide as the first. Defaults to `1`.
 
     * `:boxed` - whether the grid should be wrapped in a bordered box.
       Defaults to `false`
 
     * `:gap` - the amount of spacing between grid items in pixels.
       Defaults to `8`
-
-    * `:template` - the [`grid-template-columns`](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns)
-      style property.
-      Defaults to `repeat(\#\{assigns.columns\}, minmax(0, 1fr))`
 
   ## Examples
 
@@ -67,24 +64,12 @@ defmodule Kino.Layout do
   """
   @spec grid(list(term()), keyword()) :: t()
   def grid(terms, opts \\ []) when is_list(terms) do
-    opts =
-      Keyword.validate!(opts,
-        columns: 1,
-        boxed: false,
-        gap: 8,
-        template:
-          "repeat(#{if opts[:columns] do
-            opts[:columns]
-          else
-            1
-          end}}, minmax(0, 1fr))"
-      )
+    opts = Keyword.validate!(opts, columns: 1, boxed: false, gap: 8)
 
     info = %{
       columns: opts[:columns],
       boxed: opts[:boxed],
-      gap: opts[:gap],
-      template: opts[:template]
+      gap: opts[:gap]
     }
 
     %Kino.Layout{type: :grid, items: terms, info: info}

--- a/lib/kino/layout.ex
+++ b/lib/kino/layout.ex
@@ -43,8 +43,9 @@ defmodule Kino.Layout do
 
   ## Options
 
-    * `:columns` - the number of columns in the grid. Optionally, supports a tuple of relative column widths, e.g:
-      {4,3,8}, for three columns, with the last twice as wide as the first. Defaults to `1`.
+    * `:columns` - the number of columns in the grid. Optionally, supports
+      a tuple of column width ratio, such as `{1, 2, 1}`, for three columns,
+      where the middle one is twice as wide as the others. Defaults to `1`
 
     * `:boxed` - whether the grid should be wrapped in a bordered box.
       Defaults to `false`

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -121,6 +121,7 @@ defimpl Kino.Render, for: Kino.Layout do
       type: :grid,
       outputs: outputs,
       columns: kino.info.columns,
+      template: kino.info.template,
       gap: kino.info.gap,
       boxed: kino.info.boxed
     }

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -121,7 +121,6 @@ defimpl Kino.Render, for: Kino.Layout do
       type: :grid,
       outputs: outputs,
       columns: kino.info.columns,
-      template: kino.info.template,
       gap: kino.info.gap,
       boxed: kino.info.boxed
     }


### PR DESCRIPTION
This PR allows the behaviour of the grid to be controlled using [grid-template-columns](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns)

Example usage
<img width="934" alt="Screenshot 2024-07-23 at 13 12 37" src="https://github.com/user-attachments/assets/1c10e4ec-4d62-47f3-9097-ae8ab4d2234d">

Requires Livebook PR [#2718](https://github.com/livebook-dev/livebook/pull/2718)