### PR TITLE
Use triple quote when remote cell content contains a quote

### DIFF
--- a/lib/kino/remote_execution_cell.ex
+++ b/lib/kino/remote_execution_cell.ex
@@ -139,7 +139,7 @@ defmodule Kino.RemoteExecutionCell do
 
   defp quoted_code(code) do
     {delimiter, code} =
-      if String.contains?(code, "\n") do
+      if String.contains?(code, ["\n", ~s/"/]) do
         {~s["""], code <> "\n"}
       else
         {~s["], code}

--- a/test/kino/remote_execution_cell_test.exs
+++ b/test/kino/remote_execution_cell_test.exs
@@ -138,7 +138,14 @@ defmodule Kino.RemoteExecutionCellTest do
                require Kino.RPC
                node = :name@node
                Node.set_cookie(node, :"node-cookie")
-               Kino.RPC.eval_string(node, ~S"\"Number #{1}\"", file: __ENV__.file)
+
+               Kino.RPC.eval_string(
+                 node,
+                 ~S"""
+                 "Number #{1}"
+                 """,
+                 file: __ENV__.file
+               )
                '''
                |> String.replace_trailing("\n", "")
 


### PR DESCRIPTION
Closes #464.

We could use a different delimiter, but we would checks to find one that is not present in the string, so I think it's better to just use the triple delimiter.