### PR TITLE
Increase timeouts for frame render and append

### DIFF
--- a/lib/kino/frame.ex
+++ b/lib/kino/frame.ex
@@ -150,7 +150,7 @@ defmodule Kino.Frame do
   @doc false
   @spec get_items(t()) :: list(term())
   def get_items(frame) do
-    GenServer.call(frame.pid, :get_items)
+    GenServer.call(frame.pid, :get_items, :infinity)
   end
 
   @impl true

--- a/lib/kino/frame.ex
+++ b/lib/kino/frame.ex
@@ -82,7 +82,7 @@ defmodule Kino.Frame do
   def render(frame, term, opts \\ []) do
     opts = Keyword.validate!(opts, [:to, :temporary])
     destination = update_destination_from_opts!(opts)
-    GenServer.call(frame.pid, {:render, term, destination})
+    GenServer.call(frame.pid, {:render, term, destination}, :infinity)
   end
 
   defp update_destination_from_opts!(opts) do
@@ -122,7 +122,7 @@ defmodule Kino.Frame do
   def append(frame, term, opts \\ []) do
     opts = Keyword.validate!(opts, [:to, :temporary])
     destination = update_destination_from_opts!(opts)
-    GenServer.call(frame.pid, {:append, term, destination})
+    GenServer.call(frame.pid, {:append, term, destination}, :infinity)
   end
 
   @doc """

--- a/lib/kino/process/tracer.ex
+++ b/lib/kino/process/tracer.ex
@@ -8,7 +8,7 @@ defmodule Kino.Process.Tracer do
   end
 
   def get_trace_info(tracer) do
-    GenServer.call(tracer, :get_trace_info)
+    GenServer.call(tracer, :get_trace_info, :infinity)
   end
 
   @impl true

--- a/lib/kino/terminator.ex
+++ b/lib/kino/terminator.ex
@@ -45,7 +45,7 @@ defmodule Kino.Terminator do
   """
   def start_task(parent, fun) do
     Task.start_link(fn ->
-      GenServer.call(@name, {:monitor, self(), parent})
+      GenServer.call(@name, {:monitor, self(), parent}, :infinity)
       fun.()
     end)
   end


### PR DESCRIPTION
We run into cases where `Frame.append` from a connected node times out. There is no reason for these calls to have a timeout, so I think we are fine with `:infinity`.