### PR TITLE
Support toggling smart cell editor visibility

### DIFF
--- a/lib/kino/js/live/context.ex
+++ b/lib/kino/js/live/context.ex
@@ -111,7 +111,8 @@ defmodule Kino.JS.Live.Context do
   ## Options
 
     * `:editor` - note that the smart cell must be initialized with an
-      editor during on init. Supported options: `:source`, `:intellisense_node`.
+      editor during init. Supported options: `:source`, `:intellisense_node`,
+      `:visible`
 
   """
   @spec reconfigure_smart_cell(t(), keyword()) :: t()

--- a/lib/kino/smart_cell.ex
+++ b/lib/kino/smart_cell.ex
@@ -221,6 +221,11 @@ defmodule Kino.SmartCell do
       This is only applicable when `:language` is Elixir. Defaults to
       `nil`
 
+    * `:visible` - whether the editor is shown. Altering this option
+      with `Kino.JS.Live.Context.reconfigure_smart_cell/2` allows the
+      editor to be shown or hidden, depending on the smart cell state.
+      Defaults to `true`
+
   Note that you can programmatically reconfigure some of these options
   later using `Kino.JS.Live.Context.reconfigure_smart_cell/2`.
 

--- a/lib/kino/smart_cell/server.ex
+++ b/lib/kino/smart_cell/server.ex
@@ -25,7 +25,8 @@ defmodule Kino.SmartCell.Server do
               source: editor_opts[:source] || legacy_source,
               language: editor_opts[:language],
               placement: editor_opts[:placement],
-              intellisense_node: editor_opts[:intellisense_node]
+              intellisense_node: editor_opts[:intellisense_node],
+              visible: editor_opts[:visible]
             }
           end
 
@@ -61,7 +62,7 @@ defmodule Kino.SmartCell.Server do
                 " Make sure to enable smart cell editor during init"
       end
 
-      Keyword.validate!(editor_opts, [:source, :intellisense_node])
+      Keyword.validate!(editor_opts, [:source, :intellisense_node, :visible])
     end
 
     put_in(ctx.__private__.smart_cell[:reconfigure_options], opts)
@@ -138,7 +139,8 @@ defmodule Kino.SmartCell.Server do
           language: nil,
           intellisense_node: nil,
           placement: :bottom,
-          default_source: ""
+          default_source: "",
+          visible: true
         ])
 
       unless editor_opts[:placement] in [:top, :bottom] do


### PR DESCRIPTION

https://github.com/user-attachments/assets/a2661ee7-1797-4e6b-94f0-6111aac07e0c

<details><summary>Source</summary>

```elixir
defmodule SmartCellWithEditorToggle do
  use Kino.JS
  use Kino.JS.Live
  use Kino.SmartCell, name: "Smart cell with editor toggle"

  @impl true
  def init(attrs, ctx) do
    source = attrs["source"] || ""
    ctx = assign(ctx, source: source, visible: false)
    {:ok, ctx, editor: [source: source, visible: false]}
  end

  @impl true
  def handle_connect(ctx) do
    {:ok, %{}, ctx}
  end

  @impl true
  def handle_event("toggle_editor", %{}, ctx) do
    visible = not ctx.assigns.visible

    {:noreply,
     ctx
     |> assign(visible: visible)
     |> reconfigure_smart_cell(editor: [visible: visible])}
  end

  @impl true
  def handle_editor_change(source, ctx) do
    {:ok, assign(ctx, source: source)}
  end

  @impl true
  def to_attrs(ctx) do
    %{"source" => ctx.assigns.source}
  end

  @impl true
  def to_source(attrs) do
    attrs["source"]
  end

  asset "main.js" do
    """
    export function init(ctx, payload) {
      root.innerHTML = `
        <button id="toggle">Hide/Show</button>
      `;

      ctx.root.querySelector(`#toggle`).addEventListener("click", (event) => {
        ctx.pushEvent("toggle_editor", {});
      });
    }
    """
  end
end

Kino.SmartCell.register(SmartCellWithEditorToggle)
```

</details> 