### PR TITLE
Add `Kino.Test.push_smart_cell_editor_source/2` to test editor changes

### DIFF
--- a/lib/kino/test.ex
+++ b/lib/kino/test.ex
@@ -115,18 +115,6 @@ defmodule Kino.Test do
   end
 
   @doc """
-  Sends an editor source event to a `Kino.JS.Live` kino.
-
-  ## Examples
-
-      push_editor_source(kino, "source code")
-
-  """
-  def push_editor_source(kino, source_code) do
-    send(kino.pid, {:editor_source, source_code})
-  end
-
-  @doc """
   Connects to a `Kino.JS.Live` kino and returns the initial data.
 
   If `resolve_fun` is given, it runs after sending the connection
@@ -196,5 +184,20 @@ defmodule Kino.Test do
       assert_receive {:runtime_smart_cell_update, ^ref, unquote(attrs), unquote(source), _info},
                      unquote(timeout)
     end
+  end
+
+  @doc """
+  Sends a changed smart cell editor source to a `Kino.JS.Live` kino.
+
+  This is going to call `c:Kino.SmartCell.handle_editor_change/2` implementation
+  in the smart cell module.
+
+  ## Examples
+
+      push_smart_cell_editor_source(kino, "source code")
+
+  """
+  def push_smart_cell_editor_source(kino, source) do
+    send(kino.pid, {:editor_source, source})
   end
 end

--- a/lib/kino/test.ex
+++ b/lib/kino/test.ex
@@ -115,6 +115,18 @@ defmodule Kino.Test do
   end
 
   @doc """
+  Sends an editor source event to a `Kino.JS.Live` kino.
+
+  ## Examples
+
+      push_editor_source(kino, "source code")
+
+  """
+  def push_editor_source(kino, source_code) do
+    send(kino.pid, {:editor_source, source_code})
+  end
+
+  @doc """
   Connects to a `Kino.JS.Live` kino and returns the initial data.
 
   If `resolve_fun` is given, it runs after sending the connection


### PR DESCRIPTION
Just a little helper. I [needed it](https://github.com/livebook-dev/kino_flame/pull/3/files#diff-c52cefe4b6d3ef3ce5b7cb63552730c3a4b39030a7ed75ccd2e6985eba5ab4b5R180) and thought others might benefit from this, too.