### PR TITLE
Proposal: Add shortcut to nothing in Kino.Shorts

### DIFF
--- a/lib/kino/shorts.ex
+++ b/lib/kino/shorts.ex
@@ -9,6 +9,44 @@ defmodule Kino.Shorts do
 
   """
 
+  @doc """
+  Returns a special value that results in no visible output.
+
+  It is a wrapper around `Kino.nothing/0`.
+
+  ## Examples
+
+  Supress an otherwise verbose cell's output:
+
+      import Kino.Shorts
+
+      resp = Req.get!("https://example.org")
+      output_nothing()
+
+  For convenience, you can pipe anything into `output_nothing()`
+  to terminate a pipeline of Kinos that control their own rendering:
+
+      import Kino.Shorts
+
+      frame = frame() |> Kino.render
+      frame |> Kino.Frame.render(markdown("> ***Sumbit an event***"))
+
+      Kino.Control.form(
+        [name: Kino.Input.text("Event Name", default: "default")],
+        submit: "Render Event"
+      )
+      |> Kino.render
+      |> Kino.listen(fn
+        event ->
+          Kino.Frame.clear(frame)
+          Kino.Frame.render(frame, markdown("`\#{inspect event}`"))
+      end)
+      |> output_nothing()
+  """
+  @spec output_nothing() :: Kino.nothing()
+  @spec output_nothing(term()) :: Kino.nothing()
+  def output_nothing(_ \\ nil), do: Kino.nothing()
+
   ## Outputs
 
   @doc """


### PR DESCRIPTION
As I make more sophisticated Kino UIs:

- I find myself using `Kino.Shorts` more to streamline large complicated blocks of Elixir Kino UI code
- I find myself invariably terminating those blocks with `Kino.nothing()` since I've taken control of the rendering process

In the spirit of `Kino.Shorts` reducing the times you have to type `Kino`, I thought a shortcut function might make sense. For a use-case extracted from a pattern I've used several times now, see the second example in the function docs.

The name I've chosen here (`output_nothing`) is debatable:

- On one hand it is two characters longer than the function it is aliasing
- On the other hand it reads more clearly and declaratively than scattering kind of context-less `Kino.nothing()`s at the end of code blocks