### PR TITLE
Proposal: Make frame render functions return the frame.

### DIFF
--- a/lib/kino/frame.ex
+++ b/lib/kino/frame.ex
@@ -78,11 +78,14 @@ defmodule Kino.Frame do
       updates are never a part of frame history
 
   """
-  @spec render(t(), term(), keyword()) :: :ok
+  @spec render(t(), term(), keyword()) :: t()
   def render(frame, term, opts \\ []) do
     opts = Keyword.validate!(opts, [:to, :temporary])
     destination = update_destination_from_opts!(opts)
-    GenServer.call(frame.pid, {:render, term, destination}, :infinity)
+
+    with :ok <- GenServer.call(frame.pid, {:render, term, destination}, :infinity) do
+      frame
+    end
   end
 
   defp update_destination_from_opts!(opts) do
@@ -118,11 +121,14 @@ defmodule Kino.Frame do
       updates are never a part of frame history
 
   """
-  @spec append(t(), term(), keyword()) :: :ok
+  @spec append(t(), term(), keyword()) :: t()
   def append(frame, term, opts \\ []) do
     opts = Keyword.validate!(opts, [:to, :temporary])
     destination = update_destination_from_opts!(opts)
-    GenServer.call(frame.pid, {:append, term, destination}, :infinity)
+
+    with :ok <- GenServer.call(frame.pid, {:append, term, destination}, :infinity) do
+      frame
+    end
   end
 
   @doc """

--- a/lib/kino/frame.ex
+++ b/lib/kino/frame.ex
@@ -146,11 +146,12 @@ defmodule Kino.Frame do
       updates are never a part of frame history
 
   """
-  @spec clear(t(), keyword()) :: :ok
+  @spec clear(t(), keyword()) :: t()
   def clear(frame, opts \\ []) do
     opts = Keyword.validate!(opts, [:to, :temporary])
     destination = update_destination_from_opts!(opts)
-    GenServer.cast(frame.pid, {:clear, destination})
+    :ok = GenServer.cast(frame.pid, {:clear, destination})
+    frame
   end
 
   @doc false


### PR DESCRIPTION
This accomplishes three things in the name of pipe-ability:

- Makes `Kino.Frame.render` consistent with `Kino.render`
  This also lets you do things like [this](https://github.com/livebook-dev/kino/pull/473/files#diff-3b6d361c8ee3573b373298e73af4eec5c568d05fce5a0a95dfba4d3aa2a99b7fR31-R32):
    ```diff
    import Kino.Shorts
    - frame = frame() |> Kino.render
    - frame |> Kino.Frame.render(markdown("> ***Sumbit an event***"))
    + frame = frame() |> Kino.render() |> Kino.Frame.render(markdown("> ***Sumbit an event***"))
- Makes `Kino.Frame.append(frame, term)` more chainable
  For example:
    ```elixir
    import Kino.Shorts
    frame() |> Kino.render
    |> Kino.Frame.render(markdown("> ***Sumbit an event***"))
    |> Kino.Frame.append(markdown("- Or any term really"))
    |> Kino.Frame.append(markdown("- I'm a form, not a cop"))
    ```
- Makes `Kino.Frame.clear(frame)` chainable
  For example:
    ```elixir
    # for some existing frame and form...
    Kino.listen(form, fn event ->
      frame
      |> Kino.Frame.clear()
      |> Kino.Frame.render(markdown("`\#{inspect event}`"))
    end)
    ```

This implementation wraps the `GenServer.call`s with `with`, which technically may return something other than `:ok`, but effectively makes the same assumptions that the previous typespec did that it will always be `:ok`. We could just match on `:ok` (like in `clear`'s `cast`) or even ignore the result of the call, but this is the most backwards-compatible with any existing code today that tries to handle non-`:ok` `GenServer.call` results (I would be suprised if any such code was out there, though).