### PR TITLE
Add :max_height option for Kino.Layout.grid/2

### DIFF
--- a/lib/kino/layout.ex
+++ b/lib/kino/layout.ex
@@ -53,6 +53,10 @@ defmodule Kino.Layout do
     * `:gap` - the amount of spacing between grid items in pixels.
       Defaults to `8`
 
+    * `:max_height` - the maximum height of the grid in pixels. When
+      enabled, a scroll appears if the grid content exceeds the given
+      height
+
   ## Examples
 
       images =
@@ -65,12 +69,13 @@ defmodule Kino.Layout do
   """
   @spec grid(list(term()), keyword()) :: t()
   def grid(terms, opts \\ []) when is_list(terms) do
-    opts = Keyword.validate!(opts, columns: 1, boxed: false, gap: 8)
+    opts = Keyword.validate!(opts, columns: 1, boxed: false, gap: 8, max_height: nil)
 
     info = %{
       columns: opts[:columns],
       boxed: opts[:boxed],
-      gap: opts[:gap]
+      gap: opts[:gap],
+      max_height: opts[:max_height]
     }
 
     %Kino.Layout{type: :grid, items: terms, info: info}

--- a/lib/kino/proxy.ex
+++ b/lib/kino/proxy.ex
@@ -82,11 +82,11 @@ defmodule Kino.Proxy do
           Plug.Conn.send_resp(conn, 200, "hello world!")
         end
       end
-  
+
       Kino.Proxy.listen(MyPlug)
 
   Or a more complex example, using `Plug.Router` to handle multiple endpoints:
-  
+
       defmodule ApiRouter do
         use Plug.Router
       

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -122,6 +122,7 @@ defimpl Kino.Render, for: Kino.Layout do
       outputs: outputs,
       columns: kino.info.columns,
       gap: kino.info.gap,
+      max_height: kino.info.max_height,
       boxed: kino.info.boxed
     }
   end


### PR DESCRIPTION
It could be useful for frames where a lot of results are appended. However, instead of making it specific to frames, I think we can add it to grid, which is pretty much the API for a generic container. So to get a scrollable frame we do:

<img width="921" alt="image" src="https://github.com/user-attachments/assets/21031fa8-ab31-40f6-b5f9-775eae02dabf">