### PR TITLE
Add properties to tagged_stream entries

### DIFF
--- a/test/kino/control_test.exs
+++ b/test/kino/control_test.exs
@@ -190,7 +190,10 @@ defmodule Kino.ControlTest do
         |> Kino.Control.tagged_stream()
         |> Enum.take(2)
 
-      assert Enum.sort(events) == [{:click, %{origin: "client1"}}, {:name, %{origin: "client2"}}]
+      assert Enum.sort(events) == [
+               {%{tag: :click, properties: []}, %{origin: "client1"}},
+               {%{tag: :name, properties: []}, %{origin: "client2"}}
+             ]
     end
   end
 


### PR DESCRIPTION
Hello,

This PR is a proposition to handle the following use case:  when inputs from `Kino.Input` are generated dynamically (in my case, I need to generate an arbitrary number of checkboxes), it's quite cumbersome to get which input has generated the event. Indeed, as it's only possible to use an atom, the information must be encoded in the atom itself using `String.to_atom` and `Atom_to_string`:

```elixir
lines
|> Enum.flat_map(fn {id, _name, _amount, _date, checkbox} ->
  [{String.to_atom("l_#{id}"), checkbox}]
end)
|> Kino.Control.tagged_stream()
|> Kino.listen(fn {tag, event} ->
  %{type: :change, value: is_ticked} = event

  ["l", id_text] = String.split(Atom.to_string(tag), "_")
  {id, ""} = Integer.parse(id_text)
end)
```

So, this PR proposes to add properties to the stream:

```elixir
[{:hello, button, [id: 1]}, {:check, input, [:bar]}]
# [{:hello, button}, {:check, input}] is still supported
|> Kino.Control.tagged_stream()
|> Kino.listen(fn event -> IO.inspect(event) end)
```

The problem is: while it's possible to be  backward compatible when declaring the inputs with their tags, it breaks client code that is called whenever an event is triggered:

```elixir
...
|> Kino.listen(fn {%{tag: tag, properties: properties}, %{type: type, origin: origin}} -> ... end)
```

So, the goal of this PR is more to launch a discussion on this subject (tests are missing and there's certainly a better way to add properties).
What do you think of adding properties, and is it OK for you to break backward compatibility for this specific case?