### PR TITLE
Add Kino.Screen

### DIFF
--- a/lib/kino/screen.ex
+++ b/lib/kino/screen.ex
@@ -38,7 +38,7 @@ defmodule Kino.Screen do
         # Our screen will be placed in a grid with one additional
         # frame to render results into. And the state of the screen
         # holds the form data and the result frame itself.
-        def new(result_frame) do
+        def new do
           result_frame = Kino.Frame.new()
           state = %{data: @defaults, frame: result_frame}
 

--- a/lib/kino/screen.ex
+++ b/lib/kino/screen.ex
@@ -1,0 +1,229 @@
+defmodule Kino.Screen do
+  @moduledoc ~S"""
+  Provides a LiveView like experience for building forms in Livebook.
+
+  Each screen must implement the `c:init/1` and `c:render/1` callbacks.
+  Event handlers can be attached by calling the `control/2` function.
+  Note the screen state is shared across all users seeing the given page.
+
+  Let's see some examples.
+
+  ## Dynamic select
+
+  Here is an example that allows you to render different forms depending
+  on the value of a select, each form triggering a different action:
+
+      defmodule MyScreen do
+        @behaviour Kino.Screen
+
+        # Import Kino.Control for forms, Kino.Input for inputs, and Screen for control/2
+        import Kino.{Control, Input, Screen}
+
+        # In the state, we track the current selection and the frame to print results to
+        def init(results_frame) do
+          {:ok, %{selection: :name, frame: results_frame}}
+        end
+
+        # A form to search by name...
+        def render(%{selection: :name} = state) do
+          form(
+            [name: text("Name")],
+            submit: "Search"
+          )
+          |> control(&by_name/2)
+          |> add_layout(state)
+        end
+
+        # A form to search by address...
+        def render(%{selection: :address} = state) do
+          form(
+            [address: text("Address")],
+            submit: "Search"
+          )
+          |> control(&by_address/2)
+          |> add_layout(state)
+        end
+
+        # The general layout of the scren
+        defp add_layout(element, state) do
+          select =
+            select("Search by", [name: "Name", address: "Address"], default: state.selection)
+            |> control(&selection/2)
+
+          Kino.Layout.grid([select, element, state.frame])
+        end
+
+        ## Events handlers
+
+        defp selection(%{value: selection}, state) do
+          %{state | selection: selection}
+        end
+
+        defp by_name(%{data: %{name: name}}, state) do
+          Kino.Frame.render(state.frame, "SEARCHING BY NAME: #{name}")
+          state
+        end
+
+        defp by_address(%{data: %{address: address}}, state) do
+          Kino.Frame.render(state.frame, "SEARCHING BY ADDRESS: #{address}")
+          state
+        end
+      end
+
+      results_frame = Kino.Frame.new()
+      Kino.Screen.new(MyScreen, results_frame)
+
+  ## Wizard like
+
+  Here is an example of how to build wizard like functionality with `Kino.Screen`:
+
+      defmodule MyScreen do
+        @behaviour Kino.Screen
+
+        # Import Kino.Control for forms, Kino.Input for inputs, and Screen for control/2
+        import Kino.{Control, Input, Screen}
+
+        # Our screen will guide the user to provide its name and address.
+        # We also have a field keeping the current page and if there is an error.
+        def init(:ok) do
+          {:ok, %{page: 1, name: nil, address: nil, error: nil}}
+        end
+
+        # The first screen gets the name.
+        #
+        # The `control/2` function comes from `Kino.Screen` and it specifies
+        # which function to be invoked on form submission.
+        def render(%{page: 1} = state) do
+          form(
+            [name: text("Name", default: state.name)],
+            submit: "Step one"
+          )
+          |> control(&step_one/2)
+          |> add_layout(state)
+        end
+
+        # The next screen gets the address.
+        #
+        # We also call `add_go_back/1` to add a back button.
+        def render(%{page: 2} = state) do
+          form(
+            [address: text("Address", default: state.address)],
+            submit: "Step two"
+          )
+          |> control(&step_two/2)
+          |> add_layout(state)
+        end
+
+        # The final screen shows a success message.
+        def render(%{page: 3} = state) do
+          Kino.Text.new("Well done, #{state.name}. You live in #{state.address}.")
+          |> add_layout(state)
+        end
+
+        # This is the layout shared across all pages.
+        defp add_layout(element, state) do
+          prefix = if state.error do
+            Kino.Text.new("Error: #{state.error}!")
+          end
+
+          suffix = if state.page > 1 do
+            button("Go back")
+            |> control(&go_back/2)
+          end
+
+          [prefix, element, suffix]
+          |> Enum.reject(&is_nil/1)
+          |> Kino.Layout.grid()
+        end
+
+        ## Events handlers
+
+        defp step_one(%{data: %{name: name}}, state) do
+          if name == "" do
+            %{state | name: name, error: "name can't be blank"}
+          else
+            %{state | name: name, page: 2}
+          end
+        end
+
+        defp step_two(%{data: %{address: address}}, state) do
+          if address == "" do
+            %{state | address: address, error: "address can't be blank"}
+          else
+            %{state | address: address, page: 2}
+          end
+        end
+
+        defp go_back(_, state) do
+          %{state | page: state.page - 1}
+        end
+      end
+
+      Kino.Screen.new(MyScreen, :ok)
+  """
+
+  defmodule Server do
+    @moduledoc false
+
+    use GenServer
+
+    def start_link(mod_frame_state) do
+      GenServer.start_link(__MODULE__, mod_frame_state)
+    end
+
+    def control(from, fun) when is_function(fun, 2) do
+      Kino.Control.subscribe(from, {__MODULE__, fun})
+      from
+    end
+
+    @impl true
+    def init({module, frame, state}) do
+      {:ok, state} = module.init(state)
+      {:ok, render(module, frame, nil, state)}
+    end
+
+    @impl true
+    def handle_info({{__MODULE__, fun}, data}, {module, frame, client_id, state}) do
+      state = fun.(data, state)
+      {:noreply, render(module, frame, client_id, state)}
+    end
+
+    defp render(module, frame, client_id, state) do
+      Kino.Frame.render(frame, module.render(state), to: client_id)
+      {module, frame, client_id, state}
+    end
+  end
+
+  @typedoc "The state of the screen"
+  @type state :: term()
+
+  @doc """
+  Callback invoked when the screen is initialized.
+
+  It receives the second argument given to `new/2` and
+  it must return the screen state.
+  """
+  @callback init(state) :: {:ok, state}
+
+  @doc """
+  Callback invoked to render the screen, whenever there
+  is a control event.
+
+  It receives the state and it must return a renderable output.
+  """
+  @callback render(state) :: term()
+
+  @doc """
+  Receives a control or an input and invokes the given 2-arity function
+  once its actions are triggered.
+  """
+  @spec control(element, (map(), state() -> state())) :: element
+        when element: Kino.Control.t() | Kino.Input.t()
+  defdelegate control(element, fun), to: Server
+
+  def new(module, state) when is_atom(module) do
+    frame = Kino.Frame.new()
+    {:ok, _pid} = Kino.start_child({Server, {module, frame, state}})
+    frame
+  end
+end

--- a/lib/kino/screen.ex
+++ b/lib/kino/screen.ex
@@ -150,7 +150,7 @@ defmodule Kino.Screen do
           if address == "" do
             %{state | address: address, error: "address can't be blank"}
           else
-            %{state | address: address, page: 2}
+            %{state | address: address, page: 3}
           end
         end
 

--- a/lib/kino/screen.ex
+++ b/lib/kino/screen.ex
@@ -1,19 +1,18 @@
 defmodule Kino.Screen do
   @moduledoc ~S'''
-  Provides a LiveView like experience for building forms in Livebook.
+  Provides a LiveView-like experience for building forms in Livebook.
 
-  Each screen must implement the `c:init/1` and `c:render/1` callbacks.
-  Event handlers can be attached by calling the `control/2` function.
-
-  Each user on the page get their own version of their screen, which
-  is not shared. If you want to share them, you can pass a frame as
-  argument to the screen, as shown in the "Dynamic select" example below.
+  The screen receives its initial state and must implement the `c:render/1`
+  callback. Event handlers can be attached by calling the `control/2` function.
+  The first render of the screen is shared across all users and then further
+  interactions happen within a per-user process.
 
   ## Dynamic form/select
 
   Here is an example that allows you to build a dynamic form that renders
   values depending on the chosen options. On submit, you then process the
-  data (with optinal validation).
+  data (with optional validation) and writes the result into a separate frame.
+  The output frame could also be configured to share results across all users.
 
       defmodule MyScreen do
         @behaviour Kino.Screen
@@ -96,9 +95,9 @@ defmodule Kino.Screen do
 
       MyScreen.new()
 
-  ## Wizard like
+  ## Wizard example
 
-  Here is an example of how to build wizard like functionality with `Kino.Screen`:
+  Here is an example of how to build wizard-like functionality with `Kino.Screen`:
 
       defmodule MyScreen do
         @behaviour Kino.Screen
@@ -106,9 +105,9 @@ defmodule Kino.Screen do
         # Import Kino.Control for forms, Kino.Input for inputs, and Screen for control/2
         import Kino.{Control, Input, Screen}
 
+        # Our screen will guide the user to provide its name and address.
+        # We also have a field keeping the current page and if there is an error.
         def new do
-          # Our screen will guide the user to provide its name and address.
-          # We also have a field keeping the current page and if there is an error.
           state = %{page: 1, name: nil, address: nil, error: nil}
           Kino.Screen.new(__MODULE__, state)
         end
@@ -188,7 +187,6 @@ defmodule Kino.Screen do
 
   defmodule Server do
     @moduledoc false
-
     use GenServer
 
     def start_link(mod_frame_state) do

--- a/lib/kino/screen.ex
+++ b/lib/kino/screen.ex
@@ -21,16 +21,16 @@ defmodule Kino.Screen do
         # Import Kino.Control for forms, Kino.Input for inputs, and Screen for control/2
         import Kino.{Control, Input, Screen}
 
-        @countries [none: "", usa: "United States", canada: "Canada"]
+        @countries [nil: "", usa: "United States", canada: "Canada"]
 
         @languages [
-          usa: [none: "", en: "English", es: "Spanish"],
-          canada: [none: "", en: "English", fr: "French"]
+          usa: [nil: "", en: "English", es: "Spanish"],
+          canada: [nil: "", en: "English", fr: "French"]
         ]
 
         @defaults %{
-          country: :none,
-          language: :none
+          country: nil,
+          language: nil
         }
 
         # This is a function we will use to start the screen.
@@ -53,8 +53,7 @@ defmodule Kino.Screen do
             [
               country: country_select(data),
               language: language_select(data)
-            ]
-            |> Enum.filter(fn {_key, value} -> value != nil end),
+            ],
             report_changes: true,
             submit: "Submit"
           )
@@ -67,18 +66,16 @@ defmodule Kino.Screen do
 
         defp language_select(data) do
           if languages = @languages[data.country] do
-            default = if languages[data.language], do: data.language, else: :none
+            default = if languages[data.language], do: data.language
             select("Language", languages, default: default)
           end
         end
 
         def handle_event(%{data: data, type: :change}, state) do
-          %{state | data: Map.merge(@defaults, data)}
+          %{state | data: data}
         end
 
         def handle_event(%{data: data, type: :submit, origin: client}, state) do
-          data = Map.merge(@defaults, data)
-
           # If you want to validate the data, you could do
           # here and render a different message.
           markdown =

--- a/lib/kino/screen.ex
+++ b/lib/kino/screen.ex
@@ -130,8 +130,6 @@ defmodule Kino.Screen do
         end
 
         # The next screen gets the address.
-        #
-        # We also call `add_go_back/1` to add a back button.
         def render(%{page: 2} = state) do
           form(
             [address: text("Address", default: state.address)],
@@ -296,7 +294,6 @@ defmodule Kino.Screen do
   """
   @spec control(element, (map(), state() -> state())) :: element
         when element: Kino.Control.t() | Kino.Input.t()
-
   def control(from, fun) when is_function(fun, 2) do
     Kino.Control.subscribe(from, {__MODULE__, fun})
     from

--- a/test/kino/control_test.exs
+++ b/test/kino/control_test.exs
@@ -48,6 +48,13 @@ defmodule Kino.ControlTest do
                    end
     end
 
+    test "supports nil fields" do
+      assert %Kino.Control{attrs: %{fields: [name: %{}, age: nil]}} =
+               Kino.Control.form([name: Kino.Input.text("Name"), age: nil],
+                 submit: "Send"
+               )
+    end
+
     test "supports boolean values for :reset_on_submit" do
       assert %Kino.Control{attrs: %{reset_on_submit: [:name]}} =
                Kino.Control.form([name: Kino.Input.text("Name")],

--- a/test/kino/screen_test.exs
+++ b/test/kino/screen_test.exs
@@ -3,6 +3,16 @@ defmodule Kino.ScreenTest do
 
   import Kino.Control
 
+  defmodule MyScreen do
+    def new(rendering_fun) do
+      Kino.Screen.new(__MODULE__, rendering_fun)
+    end
+
+    def render(rendering_fun) do
+      rendering_fun.()
+    end
+  end
+
   test "renders" do
     _frame = MyScreen.new(fn -> "hello" end)
 
@@ -41,14 +51,14 @@ defmodule Kino.ScreenTest do
 
     frame =
       MyScreen.new(fn ->
-        Kino.Grid.new([
+        Kino.Layout.grid([
           Kino.Screen.control(ok_button, fn _, _ -> fn -> ok_button end end),
           Kino.Screen.control(fail_event_button, fn _, _ -> raise "oops" end),
           Kino.Screen.control(fail_render_button, fn _, _ -> fn -> raise "oops" end end)
         ])
       end)
 
-    assert_output(%{type: :frame_update, update: {:replace, [%{type: :control}]}})
+    assert_output(%{type: :frame_update, update: {:replace, [%{type: :grid}]}})
     {watcher, _dyn_sup} = screen_tree(frame)
 
     assert ExUnit.CaptureLog.capture_log(fn ->
@@ -66,16 +76,6 @@ defmodule Kino.ScreenTest do
            end) =~ "** (RuntimeError) oops"
 
     assert Process.alive?(watcher)
-  end
-
-  defmodule MyScreen do
-    def new(rendering_fun) do
-      Kino.Screen.new(__MODULE__, rendering_fun)
-    end
-
-    def render(rendering_fun) do
-      rendering_fun.()
-    end
   end
 
   defp control(button, parent) do

--- a/test/kino/screen_test.exs
+++ b/test/kino/screen_test.exs
@@ -3,37 +3,6 @@ defmodule Kino.ScreenTest do
 
   import Kino.Control
 
-  defmodule MyScreen do
-    def new(state) do
-      Kino.Screen.new(__MODULE__, state)
-    end
-
-    def render(state) do
-      state.()
-    end
-  end
-
-  defp control(button, parent) do
-    Kino.Screen.control(button, fn event, state ->
-      send(parent, {:control, event})
-      state
-    end)
-  end
-
-  defp screen_tree(frame) do
-    # Fetch screen supervision tree
-    assert_receive {:livebook_reference_object, sup, _}
-                   when is_pid(sup) and sup != self() and sup != frame.pid
-
-    [
-      {Kino.Screen.Watcher, watcher, :worker, _},
-      {DynamicSupervisor, dyn_sup, :supervisor, _}
-    ] = Supervisor.which_children(sup)
-
-    assert [] = DynamicSupervisor.which_children(dyn_sup)
-    {watcher, dyn_sup}
-  end
-
   test "renders" do
     _frame = MyScreen.new(fn -> "hello" end)
 
@@ -51,14 +20,9 @@ defmodule Kino.ScreenTest do
     assert_output(%{type: :frame_update, update: {:replace, [%{type: :control}]}})
     {watcher, dyn_sup} = screen_tree(frame)
 
-    # Click the button
-    info = %{origin: "client1"}
-    send(button.destination, {:event, button.ref, info})
-
-    assert_output_to("client1", %{
-      type: :frame_update,
-      update: {:replace, [%{type: :control}]}
-    })
+    # Verify a new user spawns a new workers
+    click_button(button, "client1")
+    assert_output_to("client1", %{type: :frame_update, update: {:replace, [%{type: :control}]}})
 
     assert [{_, user_screen, :worker, [Kino.Screen.Server]}] =
              DynamicSupervisor.which_children(dyn_sup)
@@ -71,44 +35,72 @@ defmodule Kino.ScreenTest do
   end
 
   test "does not crash tree when user event cannot be processed/rendered" do
-    button = button("hello")
+    ok_button = button("ok")
+    fail_event_button = button("fail_event")
+    fail_render_button = button("fail_render")
 
     frame =
       MyScreen.new(fn ->
-        Kino.Screen.control(button, fn
-          %{type: :succeed}, _ -> fn -> button end
-          %{type: :fail_event}, _ -> raise "oops"
-          %{type: :fail_render}, _ -> fn -> raise "oops" end
-        end)
+        Kino.Grid.new([
+          Kino.Screen.control(ok_button, fn _, _ -> fn -> ok_button end end),
+          Kino.Screen.control(fail_event_button, fn _, _ -> raise "oops" end),
+          Kino.Screen.control(fail_render_button, fn _, _ -> fn -> raise "oops" end end)
+        ])
       end)
 
     assert_output(%{type: :frame_update, update: {:replace, [%{type: :control}]}})
     {watcher, _dyn_sup} = screen_tree(frame)
 
     assert ExUnit.CaptureLog.capture_log(fn ->
-             # Click the button and make it fail
-             info = %{origin: "client1", type: :fail_event}
-             send(button.destination, {:event, button.ref, info})
-
-             # Click the button and make it succeed as a sync mechanism
-             info = %{origin: "client1", type: :succeed}
-             send(button.destination, {:event, button.ref, info})
+             click_button(fail_event_button, "client1")
+             click_button(ok_button, "client1")
              assert_output_to("client1", %{type: :frame_update})
            end) =~ "** (RuntimeError) oops"
 
     assert Process.alive?(watcher)
 
     assert ExUnit.CaptureLog.capture_log(fn ->
-             # Click the button and make it fail
-             info = %{origin: "client1", type: :fail_render}
-             send(button.destination, {:event, button.ref, info})
-
-             # Click the button and make it succeed as a sync mechanism
-             info = %{origin: "client1", type: :succeed}
-             send(button.destination, {:event, button.ref, info})
-             assert_output_to("client1", %{type: :frame_update})
+             click_button(fail_render_button, "client2")
+             click_button(ok_button, "client2")
+             assert_output_to("client2", %{type: :frame_update})
            end) =~ "** (RuntimeError) oops"
 
     assert Process.alive?(watcher)
+  end
+
+  defmodule MyScreen do
+    def new(rendering_fun) do
+      Kino.Screen.new(__MODULE__, rendering_fun)
+    end
+
+    def render(rendering_fun) do
+      rendering_fun.()
+    end
+  end
+
+  defp control(button, parent) do
+    Kino.Screen.control(button, fn event, state ->
+      send(parent, {:control, event})
+      state
+    end)
+  end
+
+  defp click_button(button, client) do
+    info = %{origin: client}
+    send(button.destination, {:event, button.ref, info})
+  end
+
+  defp screen_tree(frame) do
+    # Fetch screen supervision tree
+    assert_receive {:livebook_reference_object, sup, _}
+                   when is_pid(sup) and sup != self() and sup != frame.pid
+
+    [
+      {Kino.Screen.Watcher, watcher, :worker, _},
+      {DynamicSupervisor, dyn_sup, :supervisor, _}
+    ] = Supervisor.which_children(sup)
+
+    assert [] = DynamicSupervisor.which_children(dyn_sup)
+    {watcher, dyn_sup}
   end
 end

--- a/test/kino/screen_test.exs
+++ b/test/kino/screen_test.exs
@@ -1,0 +1,114 @@
+defmodule Kino.ScreenTest do
+  use Kino.LivebookCase, async: true
+
+  import Kino.Control
+
+  defmodule MyScreen do
+    def new(state) do
+      Kino.Screen.new(__MODULE__, state)
+    end
+
+    def render(state) do
+      state.()
+    end
+  end
+
+  defp control(button, parent) do
+    Kino.Screen.control(button, fn event, state ->
+      send(parent, {:control, event})
+      state
+    end)
+  end
+
+  defp screen_tree(frame) do
+    # Fetch screen supervision tree
+    assert_receive {:livebook_reference_object, sup, _}
+                   when is_pid(sup) and sup != self() and sup != frame.pid
+
+    [
+      {Kino.Screen.Watcher, watcher, :worker, _},
+      {DynamicSupervisor, dyn_sup, :supervisor, _}
+    ] = Supervisor.which_children(sup)
+
+    assert [] = DynamicSupervisor.which_children(dyn_sup)
+    {watcher, dyn_sup}
+  end
+
+  test "renders" do
+    _frame = MyScreen.new(fn -> "hello" end)
+
+    assert_output(%{
+      type: :frame_update,
+      update: {:replace, [%{type: :terminal_text, text: "\e[32m\"hello\"\e[0m"}]}
+    })
+  end
+
+  test "renders user update events on control" do
+    parent = self()
+    button = button("hello")
+    frame = MyScreen.new(fn -> control(button, parent) end)
+
+    assert_output(%{type: :frame_update, update: {:replace, [%{type: :control}]}})
+    {watcher, dyn_sup} = screen_tree(frame)
+
+    # Click the button
+    info = %{origin: "client1"}
+    send(button.destination, {:event, button.ref, info})
+
+    assert_output_to("client1", %{
+      type: :frame_update,
+      update: {:replace, [%{type: :control}]}
+    })
+
+    assert [{_, user_screen, :worker, [Kino.Screen.Server]}] =
+             DynamicSupervisor.which_children(dyn_sup)
+
+    # Verify the user screen terminates when the client leaves
+    ref = Process.monitor(user_screen)
+    send(watcher, {:client_leave, "unknown_client1"})
+    send(watcher, {:client_leave, "client1"})
+    assert_receive {:DOWN, ^ref, :process, ^user_screen, _}
+  end
+
+  test "does not crash tree when user event cannot be processed/rendered" do
+    button = button("hello")
+
+    frame =
+      MyScreen.new(fn ->
+        Kino.Screen.control(button, fn
+          %{type: :succeed}, _ -> fn -> button end
+          %{type: :fail_event}, _ -> raise "oops"
+          %{type: :fail_render}, _ -> fn -> raise "oops" end
+        end)
+      end)
+
+    assert_output(%{type: :frame_update, update: {:replace, [%{type: :control}]}})
+    {watcher, _dyn_sup} = screen_tree(frame)
+
+    assert ExUnit.CaptureLog.capture_log(fn ->
+             # Click the button and make it fail
+             info = %{origin: "client1", type: :fail_event}
+             send(button.destination, {:event, button.ref, info})
+
+             # Click the button and make it succeed as a sync mechanism
+             info = %{origin: "client1", type: :succeed}
+             send(button.destination, {:event, button.ref, info})
+             assert_output_to("client1", %{type: :frame_update})
+           end) =~ "** (RuntimeError) oops"
+
+    assert Process.alive?(watcher)
+
+    assert ExUnit.CaptureLog.capture_log(fn ->
+             # Click the button and make it fail
+             info = %{origin: "client1", type: :fail_render}
+             send(button.destination, {:event, button.ref, info})
+
+             # Click the button and make it succeed as a sync mechanism
+             info = %{origin: "client1", type: :succeed}
+             send(button.destination, {:event, button.ref, info})
+             assert_output_to("client1", %{type: :frame_update})
+           end) =~ "** (RuntimeError) oops"
+
+    assert Process.alive?(watcher)
+  end
+end


### PR DESCRIPTION
I choose to keep `control/2` for now because using `handle_event/3` requires us to wrap everything in `{:noreply, ...}` tuples. But if you prefer `handle_event`, let me know @hugobarauna / @jonatanklosko.

I also have to figure out how to control that a certain page should only be seen by a certain user (the `client_id`).

---

If someone wants to give it a try without depending on Kino main, here is a notebook:

`````
# Kino.Screen demo

```elixir
Mix.install [:kino]
```

## Section

```elixir
defmodule Kino.Screen do
  @moduledoc ~S"""
  Provides a LiveView like experience for building forms in Livebook.

  Each screen must implement the `c:init/1` and `c:render/1` callbacks.
  Event handlers can be attached by calling the `control/2` function.
  Note the screen state is shared across all users seeing the given page.

  Let's see some examples.

  ## Dynamic select

  Here is an example that allows you to render different forms depending
  on the value of a select, each form triggering a different action:

      defmodule MyScreen do
        @behaviour Kino.Screen

        # Import Kino.Control for forms, Kino.Input for inputs, and Screen for control/2
        import Kino.{Control, Input, Screen}

        # In the state, we track the current selection and the frame to print results to
        def init(results_frame) do
          {:ok, %{selection: :name, frame: results_frame}}
        end

        # A form to search by name...
        def render(%{selection: :name} = state) do
          form(
            [name: text("Name")],
            submit: "Search"
          )
          |> control(&by_name/2)
          |> add_layout(state)
        end

        # A form to search by address...
        def render(%{selection: :address} = state) do
          form(
            [address: text("Address")],
            submit: "Search"
          )
          |> control(&by_address/2)
          |> add_layout(state)
        end

        # The general layout of the scren
        defp add_layout(element, state) do
          select =
            select("Search by", [name: "Name", address: "Address"], default: state.selection)
            |> control(&selection/2)

          Kino.Layout.grid([select, element, state.frame])
        end

        ## Events handlers

        defp selection(%{value: selection}, state) do
          %{state | selection: selection}
        end

        defp by_name(%{data: %{name: name}}, state) do
          Kino.Frame.render(state.frame, "SEARCHING BY NAME: #{name}")
          state
        end

        defp by_address(%{data: %{address: address}}, state) do
          Kino.Frame.render(state.frame, "SEARCHING BY ADDRESS: #{address}")
          state
        end
      end

      results_frame = Kino.Frame.new()
      Kino.Screen.new(MyScreen, results_frame)

  ## Wizard like

  Here is an example of how to build wizard like functionality with `Kino.Screen`:

      defmodule MyScreen do
        @behaviour Kino.Screen

        # Import Kino.Control for forms, Kino.Input for inputs, and Screen for control/2
        import Kino.{Control, Input, Screen}

        # Our screen will guide the user to provide its name and address.
        # We also have a field keeping the current page and if there is an error.
        def init(:ok) do
          {:ok, %{page: 1, name: nil, address: nil, error: nil}}
        end

        # The first screen gets the name.
        #
        # The `control/2` function comes from `Kino.Screen` and it specifies
        # which function to be invoked on form submission.
        def render(%{page: 1} = state) do
          form(
            [name: text("Name", default: state.name)],
            submit: "Step one"
          )
          |> control(&step_one/2)
          |> add_layout(state)
        end

        # The next screen gets the address.
        #
        # We also call `add_go_back/1` to add a back button.
        def render(%{page: 2} = state) do
          form(
            [address: text("Address", default: state.address)],
            submit: "Step two"
          )
          |> control(&step_two/2)
          |> add_layout(state)
        end

        # The final screen shows a success message.
        def render(%{page: 3} = state) do
          Kino.Text.new("Well done, #{state.name}. You live in #{state.address}.")
          |> add_layout(state)
        end

        # This is the layout shared across all pages.
        defp add_layout(element, state) do
          prefix = if state.error do
            Kino.Text.new("Error: #{state.error}!")
          end

          suffix = if state.page > 1 do
            button("Go back")
            |> control(&go_back/2)
          end

          [prefix, element, suffix]
          |> Enum.reject(&is_nil/1)
          |> Kino.Layout.grid()
        end

        ## Events handlers

        defp step_one(%{data: %{name: name}}, state) do
          if name == "" do
            %{state | name: name, error: "name can't be blank"}
          else
            %{state | name: name, page: 2}
          end
        end

        defp step_two(%{data: %{address: address}}, state) do
          if address == "" do
            %{state | address: address, error: "address can't be blank"}
          else
            %{state | address: address, page: 2}
          end
        end

        defp go_back(_, state) do
          %{state | page: state.page - 1}
        end
      end

      Kino.Screen.new(MyScreen, :ok)
  """

  defmodule Server do
    @moduledoc false

    use GenServer

    def start_link(mod_frame_state) do
      GenServer.start_link(__MODULE__, mod_frame_state)
    end

    def control(from, fun) when is_function(fun, 2) do
      Kino.Control.subscribe(from, {__MODULE__, fun})
      from
    end

    @impl true
    def init({module, frame, state}) do
      {:ok, state} = module.init(state)
      {:ok, render(module, frame, nil, state)}
    end

    @impl true
    def handle_info({{__MODULE__, fun}, data}, {module, frame, client_id, state}) do
      state = fun.(data, state)
      {:noreply, render(module, frame, client_id, state)}
    end

    defp render(module, frame, client_id, state) do
      Kino.Frame.render(frame, module.render(state), to: client_id)
      {module, frame, client_id, state}
    end
  end

  @typedoc "The state of the screen"
  @type state :: term()

  @doc """
  Callback invoked when the screen is initialized.

  It receives the second argument given to `new/2` and
  it must return the screen state.
  """
  @callback init(state) :: {:ok, state}

  @doc """
  Callback invoked to render the screen, whenever there
  is a control event.

  It receives the state and it must return a renderable output.
  """
  @callback render(state) :: term()

  @doc """
  Receives a control or an input and invokes the given 2-arity function
  once its actions are triggered.
  """

  @spec control(element, (map(), state() -> state())) :: element
        when element: Kino.Control.t() | Kino.Input.t()
  defdelegate control(element, fun), to: Server

  def new(module, state) when is_atom(module) do
    frame = Kino.Frame.new()
    {:ok, _pid} = Kino.start_child({Server, {module, frame, state}})
    frame
  end
end

```

```elixir
defmodule MyScreen do
  @behaviour Kino.Screen

  # Import Kino.Control for forms, Kino.Input for inputs, and Screen for control/2
  import Kino.{Control, Input, Screen}

  def init(results_frame) do
    {:ok, %{selection: :name, frame: results_frame}}
  end

  # A form to search by name...
  def render(%{selection: :name} = state) do
    form(
      [name: text("Name")],
      submit: "Search"
    )
    |> control(&by_name/2)
    |> add_layout(state)
  end

  # A form to search by address...
  def render(%{selection: :address} = state) do
    form(
      [address: text("Address")],
      submit: "Search"
    )
    |> control(&by_address/2)
    |> add_layout(state)
  end

  # Here we add the select
  defp add_layout(element, state) do
    select =
      select("Search by", [name: "Name", address: "Address"], default: state.selection)
      |> control(&selection/2)

    Kino.Layout.grid([select, element, state.frame])
  end

  ## Events handlers

  defp selection(%{value: selection}, state) do
    %{state | selection: selection}
  end

  # On the search, you can either add new clauses
  defp by_name(%{data: %{name: name}}, state) do
    Kino.Frame.render(state.frame, "SEARCHING BY NAME: #{name}")
    state
  end

  defp by_address(%{data: %{address: address}}, state) do
    Kino.Frame.render(state.frame, "SEARCHING BY ADDRESS: #{address}")
    state
  end
end

results_frame = Kino.Frame.new()
Kino.Screen.new(MyScreen, results_frame)
`````
