### PR TITLE
Use Kino.Render.Any.to_livebook/1

### DIFF
--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -46,13 +46,13 @@ end
 
 defimpl Kino.Render, for: Any do
   def to_livebook(term) do
-    Kino.Output.inspect(term)
+    Kino.Output.to_livebook(term)
   end
 end
 
 defimpl Kino.Render, for: Kino.Inspect do
   def to_livebook(raw) do
-    Kino.Output.inspect(raw.term)
+    Kino.Render.Any.to_livebook(raw.term)
   end
 end
 
@@ -164,7 +164,7 @@ defimpl Kino.Render, for: Reference do
         reference |> Kino.ETS.new() |> Kino.Render.to_livebook()
 
       true ->
-        Kino.Output.inspect(reference)
+        Kino.Render.Any.to_livebook(reference)
     end
   end
 
@@ -198,7 +198,7 @@ defimpl Kino.Render, for: Atom do
         Kino.Render.to_livebook(tabs)
 
       true ->
-        Kino.Output.inspect(atom)
+        Kino.Render.Any.to_livebook(atom)
     end
   end
 
@@ -220,7 +220,7 @@ defimpl Kino.Render, for: PID do
         Kino.Render.to_livebook(tabs)
 
       true ->
-        Kino.Output.inspect(pid)
+        Kino.Render.Any.to_livebook(pid)
     end
   end
 end
@@ -229,7 +229,7 @@ defimpl Kino.Render, for: BitString do
   def to_livebook(string) do
     case Kino.Utils.get_image_type(string) do
       nil ->
-        Kino.Output.inspect(string)
+        Kino.Render.Any.to_livebook(string)
 
       type ->
         raw = Kino.Inspect.new(string)

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -46,7 +46,7 @@ end
 
 defimpl Kino.Render, for: Any do
   def to_livebook(term) do
-    Kino.Output.to_livebook(term)
+    Kino.Output.inspect(term)
   end
 end
 


### PR DESCRIPTION
Otherwise folks may copy and paste the contents
of this file, accidentally using Kino.Output's private
API. Relying on Kino.Render.Any is ok because that's
a public fallback.

Other options to consider: use Kino.Text |> Kino.Render.to_livebook,
although that's more verbose.
