### PR TITLE
Fix mermaid output export

### DIFF
--- a/lib/kino/js/live.ex
+++ b/lib/kino/js/live.ex
@@ -318,8 +318,8 @@ defmodule Kino.JS.Live do
   end
 
   @doc false
-  @spec output_info(t()) :: map()
-  def output_info(%__MODULE__{} = kino) do
+  @spec output_attrs(t()) :: map()
+  def output_attrs(%__MODULE__{} = kino) do
     %{
       js_view: %{
         ref: kino.ref,

--- a/lib/kino/mermaid.ex
+++ b/lib/kino/mermaid.ex
@@ -42,7 +42,7 @@ defmodule Kino.Mermaid do
     Kino.JS.new(
       __MODULE__,
       %{diagram: diagram, caption: opts[:caption], download: opts[:download]},
-      export: fn diagram -> {"mermaid", diagram} end
+      export: fn data -> {"mermaid", data.diagram} end
     )
   end
 end

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -71,7 +71,7 @@ defimpl Kino.Render, for: Kino.JS.Live do
 
   def to_livebook(kino) do
     Kino.Bridge.reference_object(kino.pid, self())
-    %{js_view: js_view, export: export} = Kino.JS.Live.output_info(kino)
+    %{js_view: js_view, export: export} = Kino.JS.Live.output_attrs(kino)
     %{type: :js, js_view: js_view, export: export}
   end
 end

--- a/lib/kino/test.ex
+++ b/lib/kino/test.ex
@@ -200,4 +200,29 @@ defmodule Kino.Test do
   def push_smart_cell_editor_source(kino, source) do
     send(kino.pid, {:editor_source, source})
   end
+
+  @doc """
+  Invokes export for the given `Kino.JS` or `Kino.JS.Live` and returns
+  the result.
+
+  For more details, see `Kino.JS.new/3` and `Kino.JS.Live.new/3`
+  respectively.
+  """
+  def export(kino, timeout \\ 100)
+
+  def export(%Kino.JS{} = kino, timeout) do
+    %{js_view: %{ref: ref, pid: pid}} = Kino.JS.output_attrs(kino)
+    do_export(ref, pid, timeout)
+  end
+
+  def export(%Kino.JS.Live{} = kino, timeout) do
+    %{js_view: %{ref: ref, pid: pid}} = Kino.JS.Live.output_attrs(kino)
+    do_export(ref, pid, timeout)
+  end
+
+  defp do_export(ref, pid, timeout) do
+    send(pid, {:export, self(), %{ref: ref}})
+    assert_receive {:export_reply, export_result, %{ref: ^ref}}, timeout
+    export_result
+  end
 end

--- a/test/kino/mermaid_test.exs
+++ b/test/kino/mermaid_test.exs
@@ -1,0 +1,17 @@
+defmodule Kino.MermaidTest do
+  use Kino.LivebookCase, async: true
+
+  test "export" do
+    content = """
+    graph TD;
+      A-->B;
+      A-->C;
+      B-->D;
+      C-->D;
+    """
+
+    kino = Kino.Mermaid.new(content)
+
+    assert export(kino) == {"mermaid", content}
+  end
+end


### PR DESCRIPTION
It would be nice to have a test for this. Maybe a `Kino.JS.export(Kino.JS.t())` function that would allow us to get the exported value?