### PR TITLE
Add Kino.JS.Live events support to subscribe/unsubscribe

### DIFF
--- a/lib/kino/control.ex
+++ b/lib/kino/control.ex
@@ -324,7 +324,7 @@ defmodule Kino.Control do
   end
 
   @doc """
-  Unsubscribes the calling process from control, input, or JS.Live events.
+  Unsubscribes the calling process from control, input, or `Kino.JS.Live` events.
   """
   @spec unsubscribe(t() | Kino.Input.t() | Kino.JS.Live.t()) :: :ok
   def unsubscribe(source)

--- a/lib/kino/control.ex
+++ b/lib/kino/control.ex
@@ -307,7 +307,7 @@ defmodule Kino.Control do
   end
 
   @doc """
-  Subscribes the calling process to control or input events.
+  Subscribes the calling process to control, input, or JS.Live events.
 
   This is an alternative API to `stream/1`, such that event
   messages are consumed via process messages instead of streams.
@@ -316,18 +316,18 @@ defmodule Kino.Control do
   event details. In particular, it always includes `:origin`, which
   is an opaque identifier of the client that triggered the event.
   """
-  @spec subscribe(t() | Kino.Input.t(), term()) :: :ok
+  @spec subscribe(t() | Kino.Input.t() | Kino.JS.Live.t(), term()) :: :ok
   def subscribe(source, tag)
-      when is_struct(source, Kino.Control) or is_struct(source, Kino.Input) do
+      when is_struct(source, Kino.Control) or is_struct(source, Kino.Input) or is_struct(source, Kino.JS.Live) do
     Kino.SubscriptionManager.subscribe(source.ref, self(), tag)
   end
 
   @doc """
-  Unsubscribes the calling process from control or input events.
+  Unsubscribes the calling process from control, input, or JS.Live events.
   """
-  @spec unsubscribe(t() | Kino.Input.t()) :: :ok
+  @spec unsubscribe(t() | Kino.Input.t() | Kino.JS.Live.t()) :: :ok
   def unsubscribe(source)
-      when is_struct(source, Kino.Control) or is_struct(source, Kino.Input) do
+      when is_struct(source, Kino.Control) or is_struct(source, Kino.Input) or is_struct(source, Kino.JS.Live) do
     Kino.SubscriptionManager.unsubscribe(source.ref, self())
   end
 

--- a/lib/kino/control.ex
+++ b/lib/kino/control.ex
@@ -318,7 +318,8 @@ defmodule Kino.Control do
   """
   @spec subscribe(t() | Kino.Input.t() | Kino.JS.Live.t(), term()) :: :ok
   def subscribe(source, tag)
-      when is_struct(source, Kino.Control) or is_struct(source, Kino.Input) or is_struct(source, Kino.JS.Live) do
+      when is_struct(source, Kino.Control) or is_struct(source, Kino.Input) or
+             is_struct(source, Kino.JS.Live) do
     Kino.SubscriptionManager.subscribe(source.ref, self(), tag)
   end
 
@@ -327,7 +328,8 @@ defmodule Kino.Control do
   """
   @spec unsubscribe(t() | Kino.Input.t() | Kino.JS.Live.t()) :: :ok
   def unsubscribe(source)
-      when is_struct(source, Kino.Control) or is_struct(source, Kino.Input) or is_struct(source, Kino.JS.Live) do
+      when is_struct(source, Kino.Control) or is_struct(source, Kino.Input) or
+             is_struct(source, Kino.JS.Live) do
     Kino.SubscriptionManager.unsubscribe(source.ref, self())
   end
 

--- a/lib/kino/control.ex
+++ b/lib/kino/control.ex
@@ -307,7 +307,7 @@ defmodule Kino.Control do
   end
 
   @doc """
-  Subscribes the calling process to control, input, or JS.Live events.
+  Subscribes the calling process to control, input, or `Kino.JS.Live` events.
 
   This is an alternative API to `stream/1`, such that event
   messages are consumed via process messages instead of streams.

--- a/test/kino/control_test.exs
+++ b/test/kino/control_test.exs
@@ -80,6 +80,16 @@ defmodule Kino.ControlTest do
 
       assert_receive {:name, ^info}
     end
+
+    test "subscribes to Kino.JS.Live events" do
+      kino = Kino.TestModules.LiveCounter.new(0)
+
+      Kino.Control.subscribe(kino, :counter)
+
+      Kino.TestModules.LiveCounter.bump(kino, 5)
+
+      assert_receive {:counter, %{event: :bump, by: 5}}
+    end
   end
 
   describe "stream/1" do


### PR DESCRIPTION
This will be useful, for example, for using custom kino in "custom form", like this one: https://gist.github.com/hugobarauna/0150a90009f737e6949c9285f34329de

So users  could build something like this:

<img width="953" height="696" alt="CleanShot 2025-07-31 at 11 13 42" src="https://github.com/user-attachments/assets/ddc838f0-dc7a-4caa-986c-fc4abbf526f9" />

Here's the code for this example: https://gist.github.com/hugobarauna/a8adeb29d67ee7dda54da8f75a82274f
