### PR TITLE
Do not override dbg_callback implicitly

### DIFF
--- a/lib/kino/application.ex
+++ b/lib/kino/application.ex
@@ -4,9 +4,6 @@ defmodule Kino.Application do
   use Application
 
   def start(_type, _args) do
-    original = Application.fetch_env!(:elixir, :dbg_callback)
-    Application.put_env(:elixir, :dbg_callback, {Kino.Debug, :dbg, [original]})
-
     Kino.AttributeStore.initialize()
 
     Kino.SmartCell.register(Kino.RemoteExecutionCell)


### PR DESCRIPTION
Currently we override `:dbg_callback` compile env at runtime, which causes issues such as https://github.com/elixir-lang/elixir/issues/15178. This PR removes it in favour of https://github.com/livebook-dev/livebook/pull/3152.