### PR TITLE
Non started processes do not have their ids quoted when needed

### DIFF
--- a/lib/kino/process.ex
+++ b/lib/kino/process.ex
@@ -795,7 +795,7 @@ defmodule Kino.Process do
   end
 
   defp graph_node(%{pid: :undefined, id: id, idx: idx}) do
-    "#{idx}(id: #{inspect(id)}):::notstarted"
+    "#{idx}(#{format_as_mermaid_unicode_text("id: #{inspect(id)}")}):::notstarted"
   end
 
   defp graph_node(%{idx: idx, id: id, meta: %{protection: protection}, type: :ets}) do

--- a/test/kino/process_test.exs
+++ b/test/kino/process_test.exs
@@ -129,10 +129,27 @@ defmodule Kino.ProcessTest do
       agent_pid_text = :erlang.pid_to_list(agent) |> List.to_string()
 
       content = Kino.Process.sup_tree(pid) |> mermaid()
-      assert content =~ "0(supervisor_parent):::root ---> 1(id: :not_started):::notstarted"
+      assert content =~ "0(supervisor_parent):::root ---> 1(\"id: :not_started\"):::notstarted"
 
       assert content =~
                "0(supervisor_parent):::root ---> 2(\"Agent<br/>#{agent_pid_text}\"):::worker"
+    end
+
+    test "quotes non-started child labels that contain special characters" do
+      pid =
+        start_supervised!(%{
+          id: Supervisor,
+          start:
+            {Supervisor, :start_link,
+             [
+               [%{id: {NonAtomId, 3}, start: {Function, :identity, [:ignore]}}],
+               [name: :supervisor_parent, strategy: :one_for_one]
+             ]},
+          restart: :temporary
+        })
+
+      content = Kino.Process.sup_tree(pid) |> mermaid()
+      assert content =~ "---> 1(\"id: {NonAtomId, 3}\"):::notstarted"
     end
 
     # TODO: remove once we require Elixir v1.17.0


### PR DESCRIPTION
This caused syntax errors for `sup_tree` for me.